### PR TITLE
マイページ：メニューを表示させるコンポーネントを作成する

### DIFF
--- a/src/app/mypage/page.module.css
+++ b/src/app/mypage/page.module.css
@@ -1,0 +1,55 @@
+.menuTitle h3 {
+  border-bottom: 2px solid black;
+  display: inline-block;
+  margin-top: 1rem;
+  margin-left: 1.5rem;
+}
+
+/* スマートフォン、タブレット */
+@media screen and (max-width: 1000px) {
+  .myPageMenuGrid {
+    display: grid;
+    place-content: center;
+    place-items: center;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .accountMenuGrid {
+    display: grid;
+    place-content: center;
+    place-items: center;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .gridRow {
+    grid-column: 1 / 3;
+    grid-row: 2;
+  }
+}
+
+/* パソコン */
+@media screen and (min-width: 1001px) {
+  .myPageMenuGrid {
+    display: grid;
+    place-content: center;
+    place-items: center;
+    grid-template-columns: repeat(4, 1fr);
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .accountMenuGrid {
+    display: grid;
+    place-content: center;
+    place-items: center;
+    grid-template-columns: repeat(4, 1fr);
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,53 @@
+import MenuBox from "@/components/mypage/MenuBox/MenuBox";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import LogoutIcon from "@mui/icons-material/Logout";
+import MusicNoteTwoToneIcon from "@mui/icons-material/MusicNoteTwoTone";
+import NoAccountsIcon from "@mui/icons-material/NoAccounts";
+import PeopleOutlineIcon from "@mui/icons-material/PeopleOutline";
+import PlayArrowTwoToneIcon from "@mui/icons-material/PlayArrowTwoTone";
+import PlaylistPlayTwoToneIcon from "@mui/icons-material/PlaylistPlayTwoTone";
+import styles from "./page.module.css";
+
+const MyPage = () => {
+  return (
+    <main>
+      <div className={styles.menuTitle}>
+        <h3>メニュー</h3>
+      </div>
+      <div className={styles.myPageMenuGrid}>
+        <MenuBox
+          mainTitle="お気に入り"
+          subTitle="楽曲"
+          icon={<MusicNoteTwoToneIcon fontSize="large" />}
+        />
+        <MenuBox
+          mainTitle="お気に入り"
+          subTitle="アーティスト"
+          icon={<PeopleOutlineIcon fontSize="large" />}
+        />
+        <MenuBox mainTitle="プレイリスト" icon={<PlaylistPlayTwoToneIcon fontSize="large" />} />
+        <MenuBox
+          mainTitle="再生履歴"
+          subTitle="（最新10件）"
+          icon={<PlayArrowTwoToneIcon fontSize="large" />}
+        />
+      </div>
+      <div className={styles.menuTitle}>
+        <h3>アカウント関連</h3>
+      </div>
+      <div className={styles.accountMenuGrid}>
+        <MenuBox
+          mainTitle="ユーザー情報"
+          subTitle="編集・確認"
+          icon={<AccountBoxIcon fontSize="large" />}
+        />
+        <MenuBox mainTitle="ログアウト" icon={<LogoutIcon fontSize="large" />} />
+        <div className={styles.gridRow}>
+          <MenuBox mainTitle="退会" icon={<NoAccountsIcon fontSize="large" />} />
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default MyPage;

--- a/src/components/mypage/MenuBox/MenuBox.module.css
+++ b/src/components/mypage/MenuBox/MenuBox.module.css
@@ -1,0 +1,13 @@
+.menuBox {
+  height: 125px;
+  width: 125px;
+  display: grid;
+  place-content: center;
+  place-items: center;
+  border: 1px solid black;
+  margin-top: 1rem;
+}
+
+.menuIcon {
+  margin-bottom: 0.5rem;
+}

--- a/src/components/mypage/MenuBox/MenuBox.test.tsx
+++ b/src/components/mypage/MenuBox/MenuBox.test.tsx
@@ -1,0 +1,18 @@
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import { render, screen } from "@testing-library/react";
+import MenuBox from "./MenuBox";
+
+describe("MenuBoxコンポーネントの単体テスト", () => {
+  test("受け取ったpropsを反映し、レンダリングされること", () => {
+    render(
+      <MenuBox
+        mainTitle="メインタイトル"
+        subTitle="サブタイトル"
+        icon={<AccountBoxIcon data-testid="icon-element" />}
+      />,
+    );
+    expect(screen.getByText("メインタイトル")).toBeInTheDocument();
+    expect(screen.getByText("サブタイトル")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-element")).toBeInTheDocument();
+  });
+});

--- a/src/components/mypage/MenuBox/MenuBox.tsx
+++ b/src/components/mypage/MenuBox/MenuBox.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import styles from "./MenuBox.module.css";
+
+type MenuBoxProps = {
+  mainTitle: string;
+  subTitle?: string;
+  icon: ReactNode;
+};
+
+const MenuBox = ({ mainTitle, subTitle, icon }: MenuBoxProps) => {
+  return (
+    <div className={styles.menuBox}>
+      <div className={styles.menuIcon}>{icon}</div>
+      <p>{mainTitle}</p>
+      <p>{subTitle}</p>
+    </div>
+  );
+};
+
+export default MenuBox;


### PR DESCRIPTION
## 概要 :bulb:

- マイページのメニューを表示させるため、MenuBoxコンポーネントを作成しました。
- マイページのPageコンポーネントを作成しました。
- メニューのアイコンはmaterial iconsから良さげなやつ見繕ってきました。

<img width="1418" alt="スクリーンショット 2024-10-15 18 15 52" src="https://github.com/user-attachments/assets/85d70001-949a-4408-aa0a-c30a69ca055d">

## 観点 :eye:

**マイページ作成(src/app/mypage/page.tsx)**
- ページコンポーネントを作成しました。
- Figmaのデザインに合わせてスタイルを作成しました。

MenuBoxコンポーネント作成(src/components/mypage/MenuBox/MenuBox.test.tsx)
- サーバコンポーネントです。
- propsでメニューの「タイトル」、「サブタイトル」、「アイコン」を取得してレンダリングします。
- 単体テスト作成して動作確認しました。

> メニューのタイトルを改行させて表示させる方法が分からなかったため、タイトル用のpropsを2つ作っていますが、自分的には気持ち悪い実装だと思っています。
> タイトルのpropsを1つだけにして、改行する方法がわかる方いましたら教えてください！

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

- MenuBoxコンポーネントに対するテストを作成(src/components/mypage/MenuBox/MenuBox.test.tsx)

## 関連する Issue :memo:

## 補足情報 :notes:

コミットメッセージのprefix付けるの忘れてすいません！

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
