### PR TITLE
トップページシングルランキング表示

### DIFF
--- a/src/app/(top)/page.tsx
+++ b/src/app/(top)/page.tsx
@@ -12,8 +12,6 @@ const TopPage = async () => {
   // シングルランキング楽曲を取得
   const singleSongs = await getRankSingleSongs(4);
 
-  console.log(newSongs, singleSongs, singleSongs.resultData[1]);
-
   return (
     <main>
       <div>

--- a/src/app/(top)/page.tsx
+++ b/src/app/(top)/page.tsx
@@ -3,9 +3,17 @@ import FreeSearch from "@/components/top/FreeSearch/FreeSearch";
 import LinkButton from "@/components/top/LinkButton/LinkButton";
 import Slider from "@/components/top/Slider/Slider";
 import SongsGroup from "@/components/top/SongsGroup/SongsGroup";
+import { getNewSongs, getRankSingleSongs } from "@/utils/apiFunc";
 import styles from "./page.module.css";
 
-const TopPage = () => {
+const TopPage = async () => {
+  // 新着人気楽曲を取得
+  const newSongs = await getNewSongs(4);
+  // シングルランキング楽曲を取得
+  const singleSongs = await getRankSingleSongs(4);
+
+  console.log(newSongs, singleSongs, singleSongs.resultData[1]);
+
   return (
     <main>
       <div>
@@ -23,7 +31,15 @@ const TopPage = () => {
             <ContentTitle title="人気新着" />
             <LinkButton label="もっと見る >" />
           </div>
-          <SongsGroup />
+          <SongsGroup songs={newSongs} />
+        </div>
+
+        <div className={styles.newSongsContent}>
+          <div className={styles.contentTitleGroup}>
+            <ContentTitle title="シングルランキング" />
+            <LinkButton label="もっと見る" />
+          </div>
+          <SongsGroup songs={singleSongs} />
         </div>
       </div>
     </main>

--- a/src/app/api/rankSingleSongSearch/route.ts
+++ b/src/app/api/rankSingleSongSearch/route.ts
@@ -1,0 +1,37 @@
+import type { DeezerSong } from "@/types/deezer";
+import { type NextRequest, NextResponse } from "next/server";
+
+export const GET = async (request: NextRequest) => {
+  try {
+    const { searchParams } = request.nextUrl;
+    const limit = searchParams.get("limit");
+
+    const singleSongs = await fetch(`https://api.deezer.com/chart/0/tracks?limit=${limit}`);
+
+    if (!singleSongs) {
+      return NextResponse.json({ message: "楽曲情報が見つかりませんでした" });
+    }
+
+    const songsData = await singleSongs.json();
+    const resultData = await songsData.data.map((data: DeezerSong) => {
+      return {
+        id: data.id,
+        title: data.title,
+        artist: {
+          id: data.artist.id,
+          name: data.artist.name,
+        },
+        album: {
+          id: data.album.id,
+          title: data.album.title,
+          cover_xl: data.album.cover_xl,
+        },
+      };
+    });
+
+    return NextResponse.json({ resultData }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラーが発生しました" });
+  }
+};

--- a/src/components/top/LinkButton/LinkButton.module.css
+++ b/src/components/top/LinkButton/LinkButton.module.css
@@ -4,4 +4,9 @@
   border-radius: 15px;
   padding: 0.3rem 0.5rem;
   display: block;
+  cursor: pointer;
+}
+
+.linkButton:hover {
+  background-color: #e2e2e2;
 }

--- a/src/components/top/SongContent/SongContent.module.css
+++ b/src/components/top/SongContent/SongContent.module.css
@@ -6,6 +6,8 @@
 .songInfo > img {
   border-radius: 10px;
   box-shadow: 0px 0px 15px -5px #777777;
+  width: 100%;
+  height: 100%;
 }
 
 .songInfo > p {

--- a/src/components/top/SongContent/SongContent.test.tsx
+++ b/src/components/top/SongContent/SongContent.test.tsx
@@ -1,4 +1,4 @@
-import { type DeezerSong, DeezerNewSongDetail } from "@/types/deezer";
+import { DeezerNewSongDetail, type DeezerSong } from "@/types/deezer";
 import { render, screen } from "@testing-library/react";
 import SongContent from "./SongContent";
 

--- a/src/components/top/SongContent/SongContent.test.tsx
+++ b/src/components/top/SongContent/SongContent.test.tsx
@@ -1,8 +1,8 @@
-import { type DeezerNewSong, DeezerNewSongDetail } from "@/types/deezer";
+import { type DeezerSong, DeezerNewSongDetail } from "@/types/deezer";
 import { render, screen } from "@testing-library/react";
 import SongContent from "./SongContent";
 
-const mockSong: DeezerNewSong = {
+const mockSong: DeezerSong = {
   id: 1,
   title: "シンデレラ",
   cover_xl: "example.jpg",
@@ -10,6 +10,10 @@ const mockSong: DeezerNewSong = {
   artist: {
     id: 2,
     name: "サイダーガール",
+  },
+  album: {
+    id: 1,
+    title: "わっしょい",
   },
 };
 

--- a/src/components/top/SongContent/SongContent.tsx
+++ b/src/components/top/SongContent/SongContent.tsx
@@ -7,7 +7,7 @@ const SongContent = ({ song }: { song: DeezerSong }) => {
     // FIXME: 後でリンクにする必要があります。
     <div className={styles.songInfo}>
       <Image
-        src={song.cover_xl ?? song.album.cover_xl}
+        src={song.cover_xl || song.album.cover_xl || ""}
         alt={`${song.title}のジャケット画像`}
         width={180}
         height={180}

--- a/src/components/top/SongContent/SongContent.tsx
+++ b/src/components/top/SongContent/SongContent.tsx
@@ -1,12 +1,17 @@
-import type { DeezerNewSong, DeezerNewSongDetail } from "@/types/deezer";
+import type { DeezerSong } from "@/types/deezer";
 import Image from "next/image";
 import styles from "./SongContent.module.css";
 
-const SongContent = ({ song }: { song: DeezerNewSong }) => {
+const SongContent = ({ song }: { song: DeezerSong }) => {
   return (
     // FIXME: 後でリンクにする必要があります。
     <div className={styles.songInfo}>
-      <Image src={song.cover_xl} alt={`${song.title}のジャケット画像`} width={180} height={180} />
+      <Image
+        src={song.cover_xl ?? song.album.cover_xl}
+        alt={`${song.title}のジャケット画像`}
+        width={180}
+        height={180}
+      />
       <p>{song.artist.name}</p>
       <p>{song.title}</p>
     </div>

--- a/src/components/top/SongsGroup/SongsGroup.tsx
+++ b/src/components/top/SongsGroup/SongsGroup.tsx
@@ -1,15 +1,11 @@
-import type { DeezerNewSong } from "@/types/deezer";
+import type { DeezerSong } from "@/types/deezer";
 import SongContent from "../SongContent/SongContent";
 import styles from "./SongsGroup.module.css";
 
-const SongsGroup = async () => {
-  // Next.jsのルートハンドラーより人気新着楽曲を4曲取得(サーバー)
-  const res = await fetch(`http://localhost:3000/api/newSongsSearch?limit=${4}`);
-  const songs = await res.json();
-
+const SongsGroup = ({ songs }: { songs: { resultData: DeezerSong[] } }) => {
   return (
     <div className={styles.newSongGroup}>
-      {songs.resultData.map((song: DeezerNewSong) => {
+      {songs.resultData.map((song: DeezerSong) => {
         return <SongContent song={song} key={song.id} />;
       })}
     </div>

--- a/src/types/deezer.ts
+++ b/src/types/deezer.ts
@@ -99,6 +99,6 @@ export type DeezerSong = {
   album: {
     id: number;
     title: string;
-    cover_xl: string;
+    cover_xl?: string;
   };
 };

--- a/src/types/deezer.ts
+++ b/src/types/deezer.ts
@@ -49,7 +49,7 @@ export type DeezerSearch = {
   next?: string;
 };
 
-// deezerにて新着楽曲情報を取得した際の型
+// deezerにて楽曲情報を取得した際の型
 export type DeezerNewRelease = {
   id: number;
   title: string;
@@ -87,13 +87,18 @@ export type DeezerNewSongDetail = {
   };
 };
 
-export type DeezerNewSong = {
+export type DeezerSong = {
   id: number;
   title: string;
-  cover_xl: string;
-  release_date: string;
+  cover_xl?: string;
+  release_date?: string;
   artist: {
     id: number;
     name: string;
+  };
+  album: {
+    id: number;
+    title: string;
+    cover_xl: string;
   };
 };

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -1,0 +1,11 @@
+// 人気新着楽曲を取得する関数
+export const getNewSongs = async (limit: number) => {
+  const res = await fetch(`http://localhost:3000/api/newSongsSearch?limit=${limit}`);
+  return await res.json();
+};
+
+// シングルランキング楽曲を取得する関数
+export const getRankSingleSongs = async (limit: number) => {
+  const res = await fetch(`http://localhost:3000/api/rankSingleSongSearch?limit=${limit}`);
+  return await res.json();
+};

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -1,11 +1,29 @@
 // 人気新着楽曲を取得する関数
 export const getNewSongs = async (limit: number) => {
-  const res = await fetch(`http://localhost:3000/api/newSongsSearch?limit=${limit}`);
-  return await res.json();
+  try {
+    const res = await fetch(`http://localhost:3000/api/newSongsSearch?limit=${limit}`);
+
+    if (!res.ok) {
+      throw new Error("データが見つかりませんでした");
+    }
+
+    return await res.json();
+  } catch (error) {
+    console.error(error);
+  }
 };
 
 // シングルランキング楽曲を取得する関数
 export const getRankSingleSongs = async (limit: number) => {
-  const res = await fetch(`http://localhost:3000/api/rankSingleSongSearch?limit=${limit}`);
-  return await res.json();
+  try {
+    const res = await fetch(`http://localhost:3000/api/rankSingleSongSearch?limit=${limit}`);
+
+    if (!res.ok) {
+      throw new Error("データが見つかりませんでした");
+    }
+
+    return await res.json();
+  } catch (error) {
+    console.error(error);
+  }
 };


### PR DESCRIPTION
## 概要 :bulb:
- トップページにシングルランキングを4曲表示するようにしました。
<img width="1364" alt="スクリーンショット 2024-10-16 11 14 23" src="https://github.com/user-attachments/assets/d2cff3e4-cb7e-4a0b-abc1-d4be91e1a62d">


## 観点 :eye:
- シングルランキングを取得するAPIを作成(/api/rankSingleSongSearch)
- 曲情報をトップページにて取得し、子コンポーネントにpropsとして送るように変更
- 曲情報を取得する関数を作成(utils/apiFunc.ts)
- LinkButtonコンポーネントのホバー時のCSSを調整

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

## 関連する Issue :memo:

## 補足情報 :notes:

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
