### PR TITLE
トップページ-ジャンルコンテンツ追加

### DIFF
--- a/src/app/(top)/page.module.css
+++ b/src/app/(top)/page.module.css
@@ -1,11 +1,13 @@
 .specialContent,
 .freeSearchContent,
-.newSongsContent {
+.newSongsContent,
+.genreContent {
   margin: 1.5rem 1rem;
 }
 
 .freeSearchContent,
-.newSongsContent {
+.newSongsContent,
+.genreContent {
   padding-bottom: 2rem;
   border-bottom: 1px solid #55555542;
 }

--- a/src/app/(top)/page.tsx
+++ b/src/app/(top)/page.tsx
@@ -1,5 +1,6 @@
 import ContentTitle from "@/components/top/ContentTitle/ContentTitle";
 import FreeSearch from "@/components/top/FreeSearch/FreeSearch";
+import GenreGroup from "@/components/top/GenreGroup/GenreGroup";
 import LinkButton from "@/components/top/LinkButton/LinkButton";
 import Slider from "@/components/top/Slider/Slider";
 import SongsGroup from "@/components/top/SongsGroup/SongsGroup";
@@ -38,6 +39,10 @@ const TopPage = async () => {
             <LinkButton label="もっと見る" />
           </div>
           <SongsGroup songs={singleSongs} />
+        </div>
+        <div className={styles.genreContent}>
+          <ContentTitle title="ジャンル一覧" />
+          <GenreGroup />
         </div>
       </div>
     </main>

--- a/src/app/api/genreArtistSearch/route.ts
+++ b/src/app/api/genreArtistSearch/route.ts
@@ -1,0 +1,32 @@
+import type { GenreApiArtist } from "@/types/deezer";
+import { type NextRequest, NextResponse } from "next/server";
+
+// ジャンルごとのアーティスト情報を取得するAPI
+export const GET = async (request: NextRequest) => {
+  try {
+    const { searchParams } = request.nextUrl;
+    const genre = searchParams.get("genre");
+
+    const genreArtists = await fetch(`https://api.deezer.com/genre/${genre}/artists`);
+
+    if (!genreArtists) {
+      return NextResponse.json({
+        message: "アーティスト情報が見つかりませんでした",
+      });
+    }
+
+    const artistsData = await genreArtists.json();
+    const resultData = await artistsData.data.map((data: GenreApiArtist) => {
+      return {
+        id: data.id,
+        name: data.name,
+        picture_xl: data.picture_xl,
+      };
+    });
+
+    return NextResponse.json({ resultData }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラーが発生しました" }, { status: 500 });
+  }
+};

--- a/src/components/top/GenreContent/GenreContent.module.css
+++ b/src/components/top/GenreContent/GenreContent.module.css
@@ -1,0 +1,22 @@
+.genreContent {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+
+.genreContent > button {
+  padding: 0.5rem 0.6rem;
+  font-weight: bold;
+  color: white;
+  background-color: #a8a8a8;
+  border-radius: 10px;
+  border: none;
+  box-shadow: 0px 0px 15px -5px #777777;
+  flex: 1;
+}
+
+.genreContent > button:hover {
+  background-color: #cdcdcd;
+  cursor: pointer;
+}

--- a/src/components/top/GenreContent/GenreContent.test.tsx
+++ b/src/components/top/GenreContent/GenreContent.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import GenreContent from "./GenreContent";
+
+describe("GenreContentコンポーネントの単体テスト", () => {
+  test("受け取ったpropsを反映し、レンダリングされること", () => {
+    render(<GenreContent genre={{ id: 1, name: "洋楽" }} />);
+    expect(screen.getByText("洋楽")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+});

--- a/src/components/top/GenreContent/GenreContent.tsx
+++ b/src/components/top/GenreContent/GenreContent.tsx
@@ -1,0 +1,12 @@
+import type { GenreArtist } from "@/types/deezer";
+import styles from "./GenreContent.module.css";
+
+const GenreContent = ({ genre }: { genre: GenreArtist }) => {
+  return (
+    <div className={styles.genreContent}>
+      <button type="button">{genre.name}</button>
+    </div>
+  );
+};
+
+export default GenreContent;

--- a/src/components/top/GenreGroup/GenreGroup.module.css
+++ b/src/components/top/GenreGroup/GenreGroup.module.css
@@ -1,0 +1,8 @@
+.genreGroup {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  gap: 1.5rem;
+  place-items: center;
+  margin-top: 1rem;
+}

--- a/src/components/top/GenreGroup/GenreGroup.tsx
+++ b/src/components/top/GenreGroup/GenreGroup.tsx
@@ -1,0 +1,16 @@
+import { GENRE_ARTISTS } from "@/constants/constant";
+import type { GenreArtist } from "@/types/deezer";
+import GenreContent from "../GenreContent/GenreContent";
+import styles from "./GenreGroup.module.css";
+
+const GenreGroup = () => {
+  return (
+    <div className={styles.genreGroup}>
+      {GENRE_ARTISTS.map((genre: GenreArtist) => {
+        return <GenreContent genre={genre} key={genre.id} />;
+      })}
+    </div>
+  );
+};
+
+export default GenreGroup;

--- a/src/components/top/SongContent/SongContent.tsx
+++ b/src/components/top/SongContent/SongContent.tsx
@@ -11,6 +11,7 @@ const SongContent = ({ song }: { song: DeezerSong }) => {
         alt={`${song.title}のジャケット画像`}
         width={180}
         height={180}
+        priority
       />
       <p>{song.artist.name}</p>
       <p>{song.title}</p>

--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -5,3 +5,16 @@ export const SLIDER_IMAGES = [
   "/images/sliderImage3.png",
   "/images/sliderImage4.png",
 ];
+
+// 表示させるアーティストのジャンル
+export const GENRE_ARTISTS = [
+  { id: 0, name: "全て" },
+  { id: 132, name: "ポップス" },
+  { id: 152, name: "ロック" },
+  { id: 165, name: "R&B" },
+  { id: 113, name: "ダンス" },
+  { id: 464, name: "メタル" },
+  { id: 16, name: "アジア音楽" },
+  { id: 95, name: "キッズ" },
+  { id: 173, name: "映画/ゲーム" },
+];

--- a/src/types/deezer.ts
+++ b/src/types/deezer.ts
@@ -102,3 +102,23 @@ export type DeezerSong = {
     cover_xl?: string;
   };
 };
+
+// ジャンルの型
+export type GenreArtist = {
+  id: number;
+  name: string;
+};
+
+// apiから返されるジャンルごとのアーティスト
+export type GenreApiArtist = {
+  id: number;
+  name: string;
+  picture: string;
+  picture_small: string;
+  picture_medium: string;
+  picture_big: string;
+  picture_xl: string;
+  radio: boolean;
+  tracklist: string;
+  type: string;
+};

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -1,4 +1,5 @@
 // 人気新着楽曲を取得する関数
+// limitには取得したい件数を入力
 export const getNewSongs = async (limit: number) => {
   try {
     const res = await fetch(`http://localhost:3000/api/newSongsSearch?limit=${limit}`);
@@ -14,9 +15,26 @@ export const getNewSongs = async (limit: number) => {
 };
 
 // シングルランキング楽曲を取得する関数
+// limitには取得したい件数を入力
 export const getRankSingleSongs = async (limit: number) => {
   try {
     const res = await fetch(`http://localhost:3000/api/rankSingleSongSearch?limit=${limit}`);
+
+    if (!res.ok) {
+      throw new Error("データが見つかりませんでした");
+    }
+
+    return await res.json();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// ジャンルごとのアーティスト情報を取得する関数
+// genreにはgenreのid
+export const getGenreArtist = async (genre: number) => {
+  try {
+    const res = await fetch(`http://localhost:3000/api/genreArtistSearch?genre=${genre}`);
 
     if (!res.ok) {
       throw new Error("データが見つかりませんでした");


### PR DESCRIPTION
## 概要 :bulb:
- トップページにジャンルコンテンツ追加
- ジャンルごとのアーティスト情報を取得するAPIおよび関数作成
<img width="1402" alt="スクリーンショット 2024-10-16 15 08 45" src="https://github.com/user-attachments/assets/b63635a3-d49e-497c-8b8d-1a878656e5f2">


## 観点 :eye:
#### ジャンルボタンコンポーネント作成(/components/top/GenreContent)
-こちらは後でリンクにする必要があります。(それかuseRouter)
- 単体テスト作成 OK

#### ジャンルボタングループコンポーネント作成(/components/top/GenreGroup)
- 子コンポーネントである、GenreContentにpropsでジャンル名とidを渡しています。
- 表示するジャンルは私の独断で選別したので、変えて欲しいものがありましたら意見をください。

#### ジャンル別アーティスト情報取得API作成(/api/genreArtistSearch)
- genreのidを渡してジャンルごとのアーティスト情報を取得できます。
- 関数化もしてあります。

#### ジャンルに関して
- 今回、楽曲ごとのジャンルの習得ができなかったため、アーティストとなっています。
方法が見つかりましたら楽曲ごとに変更します。

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:
- GenreContentコンポーネント単体テスト作成

## 関連する Issue :memo:

## 補足情報 :notes:

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
