### PR TITLE
パンくずリストコンポーネント作成

### DIFF
--- a/src/app/(top)/page.tsx
+++ b/src/app/(top)/page.tsx
@@ -1,3 +1,4 @@
+import BreadList from "@/components/top/BreadList/BreadList";
 import ContentTitle from "@/components/top/ContentTitle/ContentTitle";
 import FreeSearch from "@/components/top/FreeSearch/FreeSearch";
 import GenreGroup from "@/components/top/GenreGroup/GenreGroup";
@@ -15,6 +16,7 @@ const TopPage = async () => {
 
   return (
     <main>
+      <BreadList bread={[{ link: "/", title: "TOP" }]} />
       <div>
         <div className={styles.specialContent}>
           <ContentTitle title="特集" />
@@ -36,7 +38,7 @@ const TopPage = async () => {
         <div className={styles.newSongsContent}>
           <div className={styles.contentTitleGroup}>
             <ContentTitle title="シングルランキング" />
-            <LinkButton label="もっと見る" />
+            <LinkButton label="もっと見る >" />
           </div>
           <SongsGroup songs={singleSongs} />
         </div>

--- a/src/components/top/BreadList/BreadList.module.css
+++ b/src/components/top/BreadList/BreadList.module.css
@@ -1,0 +1,13 @@
+.breadListGroup {
+  background-color: #c0ffe7;
+  padding: 0.7rem 1rem;
+  font-size: 0.8rem;
+}
+
+.breadListGroup > span {
+  margin: 0 1rem;
+}
+
+.breadListTitle:hover {
+  color: #b1b1b1;
+}

--- a/src/components/top/BreadList/BreadList.test.tsx
+++ b/src/components/top/BreadList/BreadList.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import BreadList from "./BreadList";
+
+describe("BreadListコンポーネントの単体テスト", () => {
+  test("受け取ったpropsを反映して、レンダリングされるか", () => {
+    render(
+      <BreadList
+        bread={[
+          { link: "/", title: "TOP" },
+          { link: "/", title: "アーティスト" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "TOP" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "アーティスト" })).toBeInTheDocument();
+  });
+});

--- a/src/components/top/BreadList/BreadList.tsx
+++ b/src/components/top/BreadList/BreadList.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import styles from "./BreadList.module.css";
+
+type BreadProps = {
+  bread: {
+    link: string;
+    title: string;
+  }[];
+};
+
+const BreadList = ({ bread }: BreadProps) => {
+  const breadList = Object.entries(bread);
+  return (
+    <div className={styles.breadListGroup}>
+      {breadList.map((bread: [string, { link: string; title: string }]) => {
+        return (
+          <div key={bread[0]}>
+            <Link href={bread[1].link}>
+              <span className={styles.breadListTitle}>{bread[1].title}</span>
+            </Link>
+            {Number(bread[0]) !== breadList.length - 1 ? <span>&gt;</span> : <></>}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default BreadList;


### PR DESCRIPTION
## 概要 :bulb:
- パンくずリスト作成
<img width="1440" alt="スクリーンショット 2024-10-16 17 30 19" src="https://github.com/user-attachments/assets/e10fa812-d88d-4799-9756-c29658d77036">


## 観点 :eye:
#### パンくずリスト用コンポーネント作成(components/top/BreadList)
- 以下のようなpropsを渡すことで、パンクズリストを表示できます。
```
[{link: string, title: string}, .....]
```
- タイトル箇所はリンクとなっています。
- 単体テスト作成 OK

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:
- BreadListコンポーネント単体テスト作成

## 関連する Issue :memo:

## 補足情報 :notes:

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
