### PR TITLE
楽曲詳細ページ作成

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -32,6 +32,9 @@
       "style": {
         "noNamespace": "error",
         "noUselessElse": "off"
+      },
+      "a11y": {
+        "useMediaCaption": "off"
       }
     }
   },

--- a/src/app/(top)/page.tsx
+++ b/src/app/(top)/page.tsx
@@ -32,7 +32,7 @@ const TopPage = async () => {
             <ContentTitle title="人気新着" />
             <LinkButton label="もっと見る >" />
           </div>
-          <SongsGroup songs={newSongs} />
+          <SongsGroup songs={newSongs} url="album" />
         </div>
 
         <div className={styles.newSongsContent}>
@@ -40,7 +40,7 @@ const TopPage = async () => {
             <ContentTitle title="シングルランキング" />
             <LinkButton label="もっと見る >" />
           </div>
-          <SongsGroup songs={singleSongs} />
+          <SongsGroup songs={singleSongs} url="music" />
         </div>
         <div className={styles.genreContent}>
           <ContentTitle title="ジャンル一覧" />

--- a/src/app/api/artistFavoriteSongs/route.ts
+++ b/src/app/api/artistFavoriteSongs/route.ts
@@ -1,0 +1,51 @@
+import type { ContributorsInfo, FavoriteArtistSong } from "@/types/deezer";
+import { type NextRequest, NextResponse } from "next/server";
+
+export const GET = async (request: NextRequest) => {
+  try {
+    const { searchParams } = request.nextUrl;
+    const artistId = searchParams.get("artistId");
+    const limit = searchParams.get("limit");
+
+    const artistFavoriteSongs = await fetch(
+      `https://api.deezer.com/artist/${artistId}/top?limit=${limit}`,
+    );
+
+    if (!artistFavoriteSongs) {
+      return NextResponse.json(
+        {
+          message: "アーティストの人気楽曲は見つかりませんでした",
+        },
+        { status: 404 },
+      );
+    }
+
+    const artistFavoriteSongsData = await artistFavoriteSongs.json();
+    const resultData = await artistFavoriteSongsData.data.map((data: FavoriteArtistSong) => {
+      const artistImage = data.contributors.find(
+        (contributor: ContributorsInfo) => contributor.name === data.artist.name,
+      );
+      return {
+        id: data.id,
+        title: data.title,
+        preview: data.preview,
+        duration: data.duration,
+        artist: {
+          id: data.artist.id,
+          name: data.artist.name,
+          image: artistImage?.picture_big,
+        },
+        album: {
+          id: data.album.id,
+          title: data.album.title,
+          cover_xl: data.album.cover_big,
+        },
+      };
+    });
+
+    return NextResponse.json({ resultData }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラーが発生しました" }, { status: 500 });
+  }
+};

--- a/src/app/api/songSearch/route.ts
+++ b/src/app/api/songSearch/route.ts
@@ -20,9 +20,11 @@ export const GET = async (request: NextRequest) => {
       title: songData.title,
       cover_xl: songData.album.cover_xl,
       release_date: songData.album.release_date,
+      preview: songData.preview,
       artist: {
         id: songData.artist.id,
         name: songData.artist.name,
+        picture_xl: songData.artist.picture_xl,
       },
       album: {
         id: songData.album.id,

--- a/src/app/music/[id]/page.module.css
+++ b/src/app/music/[id]/page.module.css
@@ -1,0 +1,13 @@
+.songPageContent {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.artistInfoLinkContent,
+.artistFavoriteSongsContent,
+.songDetailContent {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 2px solid #c7c7c7;
+}

--- a/src/app/music/[id]/page.tsx
+++ b/src/app/music/[id]/page.tsx
@@ -1,0 +1,60 @@
+import ImageTitleLink from "@/components/music/ImageTitleLink/ImageTitleLink";
+import MusicContentTitle from "@/components/music/MusicContentTitle/MusicContentTitle";
+import SongInfoContent from "@/components/music/SongInfoContent/SongInfoContent";
+import SongList from "@/components/mypage/SongList/SongList";
+import BreadList from "@/components/top/BreadList/BreadList";
+import { getArtistSongs, getSong } from "@/utils/apiFunc";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import styles from "./page.module.css";
+
+type SongPageProps = {
+  params: { id: string };
+  searchParams: ReadonlyURLSearchParams;
+};
+
+const SongPage = async ({ params }: SongPageProps) => {
+  // クエリパラメーターから楽曲id取得
+  const { id } = params;
+
+  // 取得したidの楽曲情報を取得
+  const { resSongData } = await getSong(Number(id));
+
+  // 上記で取得したアーティストIDからアーティストの人気楽曲を最大4件取得
+  const songs = await getArtistSongs(resSongData.artist.id, 4);
+
+  return (
+    <>
+      <BreadList
+        bread={[
+          { link: "/", title: "TOP" },
+          { link: "/music/1", title: "楽曲詳細" },
+        ]}
+      />
+      <div className={styles.songPageContent}>
+        <div className={styles.songDetailContent}>
+          <SongInfoContent
+            title={resSongData.title}
+            artist={resSongData.artist.name}
+            image={resSongData.cover_xl}
+            preview={resSongData.preview}
+          />
+        </div>
+        <div className={styles.artistInfoLinkContent}>
+          <MusicContentTitle title="アーティスト情報" />
+          <ImageTitleLink
+            id={resSongData.artist.id}
+            name={resSongData.artist.name}
+            image={resSongData.artist.picture_xl}
+          />
+        </div>
+
+        <div className={styles.artistFavoriteSongsContent}>
+          <MusicContentTitle title="人気楽曲" />
+          <SongList songs={songs.resultData} errorMessage="人気楽曲を取得できませんでした" />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default SongPage;

--- a/src/app/music/[id]/page.tsx
+++ b/src/app/music/[id]/page.tsx
@@ -42,7 +42,7 @@ const SongPage = async ({ params }: SongPageProps) => {
         <div className={styles.artistInfoLinkContent}>
           <MusicContentTitle title="アーティスト情報" />
           <ImageTitleLink
-            id={resSongData.artist.id}
+            url={`/artist/${resSongData.artist.id}`}
             name={resSongData.artist.name}
             image={resSongData.artist.picture_xl}
           />

--- a/src/app/mypage/favoritesong/page.tsx
+++ b/src/app/mypage/favoritesong/page.tsx
@@ -23,7 +23,7 @@ const FavoriteSongs = async () => {
       <MenuHeader title="お気に入り楽曲" />
       <SortButtons label="登録日" />
       <EditButton />
-      <SongList songs={favoriteSongsInfo} />
+      <SongList songs={favoriteSongsInfo} errorMessage="お気に入り曲は登録されていません" />
     </div>
   );
 };

--- a/src/components/music/ImageTitleLink/ImageTitleLink.module.css
+++ b/src/components/music/ImageTitleLink/ImageTitleLink.module.css
@@ -1,0 +1,17 @@
+.imageTitleContent {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.imageTitleContent > img {
+  border-radius: 9999px;
+  box-shadow: 0px 0px 15px -5px #777777;
+  width: 35%;
+  height: 35%;
+}
+
+.imageTitleContent > p {
+  text-align: center;
+}

--- a/src/components/music/ImageTitleLink/ImageTitleLink.test.tsx
+++ b/src/components/music/ImageTitleLink/ImageTitleLink.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import ImageTitleLink from "./ImageTitleLink";
+
+describe("ImageTitleLinkコンポーネント単体テスト", () => {
+  test("受け取ったpropsを反映し、レンダリングされること", () => {
+    render(<ImageTitleLink url="/artist/1" name="Aquatimez" image="example.jpeg" />);
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "Aquatimezの画像");
+    expect(screen.getByText("Aquatimez")).toBeInTheDocument();
+  });
+});

--- a/src/components/music/ImageTitleLink/ImageTitleLink.tsx
+++ b/src/components/music/ImageTitleLink/ImageTitleLink.tsx
@@ -1,0 +1,24 @@
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import Image from "next/image";
+import Link from "next/link";
+import styles from "./ImageTitleLink.module.css";
+
+type ImageTitleLinkProps = {
+  name: string;
+  image: string;
+  url: string;
+};
+
+const ImageTitleLink = ({ name, image, url }: ImageTitleLinkProps) => {
+  return (
+    <div>
+      <Link href={url} className={styles.imageTitleContent}>
+        <Image src={image} alt={`${name}の画像`} width={150} height={150} priority />
+        <p>{name}</p>
+        <ArrowForwardIosIcon fontSize="small" color="disabled" />
+      </Link>
+    </div>
+  );
+};
+
+export default ImageTitleLink;

--- a/src/components/music/MusicContentTitle/MusicContentTitle.module.css
+++ b/src/components/music/MusicContentTitle/MusicContentTitle.module.css
@@ -1,0 +1,4 @@
+.contentTitle {
+  font-size: 1.2rem;
+  font-weight: 600;
+}

--- a/src/components/music/MusicContentTitle/MusicContentTitle.test.tsx
+++ b/src/components/music/MusicContentTitle/MusicContentTitle.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import MusicContentTitle from "./MusicContentTitle";
+
+describe("MusicContentTitleコンポーネント単体テスト", () => {
+  test("受け取ったpropsを反映し、レンダリングされること", () => {
+    render(<MusicContentTitle title="アーティスト情報" />);
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+    expect(screen.getByText("アーティスト情報")).toBeInTheDocument();
+  });
+});

--- a/src/components/music/MusicContentTitle/MusicContentTitle.tsx
+++ b/src/components/music/MusicContentTitle/MusicContentTitle.tsx
@@ -1,0 +1,7 @@
+import styles from "./MusicContentTitle.module.css";
+
+const MusicContentTitle = ({ title }: { title: string }) => {
+  return <h2 className={styles.contentTitle}>{title}</h2>;
+};
+
+export default MusicContentTitle;

--- a/src/components/music/SongAudio/SongAudio.module.css
+++ b/src/components/music/SongAudio/SongAudio.module.css
@@ -1,0 +1,10 @@
+.sliderContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.errorMessage {
+  color: red;
+}

--- a/src/components/music/SongAudio/SongAudio.tsx
+++ b/src/components/music/SongAudio/SongAudio.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import MusicNoteIcon from "@mui/icons-material/MusicNote";
+import PlayCircleIcon from "@mui/icons-material/PlayCircle";
+import StopCircleIcon from "@mui/icons-material/StopCircle";
+import Slider from "@mui/material/Slider";
+import { useEffect, useRef, useState } from "react";
+import styles from "./SongAudio.module.css";
+
+const SongAudio = ({ preview }: { preview?: string }) => {
+  // 再生中かどうかstateで管理
+  const [isPlaying, setIsPlaying] = useState(false);
+  // 再レンダリングさせたくないので、useRefでaudio要素を参照
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  // 現在の再生時間
+  const [currentTime, setCurrentTime] = useState(0);
+  // 曲の総再生時間
+  const [duration, setDuration] = useState(30);
+
+  // スライダー動作に関わる処理全て
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (audio) {
+      // 再生中の時間を更新
+      const handleTimeUpdate = () => {
+        setCurrentTime(audio.currentTime);
+      };
+      // 曲の再生時間を取得
+      const handleLoadedMetadata = () => {
+        setDuration(audio.duration);
+      };
+
+      audio.addEventListener("timeupdate", handleTimeUpdate);
+      audio.addEventListener("loadedmetadata", handleLoadedMetadata);
+
+      // アンマウント時に削除
+      return () => {
+        audio.removeEventListener("timeupdate", handleTimeUpdate);
+        audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
+      };
+    }
+  }, []);
+
+  // 曲の再生位置を変更
+  const handleSliderChange = (_event: Event, newValue: number | number[]) => {
+    if (audioRef.current && typeof newValue === "number") {
+      audioRef.current.currentTime = newValue;
+      setCurrentTime(newValue);
+    }
+  };
+
+  // 曲を再生
+  const handlePlay = () => {
+    if (audioRef.current) {
+      audioRef.current.play();
+      setIsPlaying(true);
+    }
+  };
+
+  // 曲を一時停止
+  const handlePause = () => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      setIsPlaying(false);
+    }
+  };
+
+  // 再生終了後
+  const handleEnded = () => {
+    setIsPlaying(false);
+  };
+
+  return (
+    <div>
+      {preview ? (
+        <>
+          <audio src={preview} ref={audioRef} onEnded={handleEnded} />
+          <div>
+            <PlayCircleIcon
+              sx={{
+                fontSize: 32,
+                color: isPlaying ? "#9a9a9a" : "#77ffcc",
+                cursor: "pointer",
+              }}
+              onClick={handlePlay}
+              style={{ pointerEvents: isPlaying ? "none" : "auto" }}
+            />
+            <StopCircleIcon
+              sx={{
+                fontSize: 32,
+                color: isPlaying ? "#77ffcc" : "#9a9a9a",
+                cursor: "pointer",
+              }}
+              onClick={handlePause}
+              style={{ pointerEvents: isPlaying ? "auto" : "none" }}
+            />
+          </div>
+          <div className={styles.sliderContent}>
+            <MusicNoteIcon sx={{ color: "#77ffcc" }} />
+            <Slider
+              value={currentTime}
+              max={duration}
+              onChange={handleSliderChange}
+              sx={{ color: "#77ffcc" }}
+            />
+          </div>
+        </>
+      ) : (
+        <p className={styles.errorMessage}>プレビューが読み込めませんでした。</p>
+      )}
+    </div>
+  );
+};
+
+export default SongAudio;

--- a/src/components/music/SongInfoContent/SongInfoContent.module.css
+++ b/src/components/music/SongInfoContent/SongInfoContent.module.css
@@ -38,8 +38,8 @@
 .songInfoAddList {
   display: flex;
   background-color: white;
-  color: #77ffcc;
-  border: 2px solid #77ffcc;
+  color: #abc8ff;
+  border: 2px solid #abc8ff;
   border-radius: 10px;
   justify-content: center;
   align-items: center;
@@ -49,8 +49,28 @@
   cursor: pointer;
 }
 
+.songInfoAddFavorite {
+  display: flex;
+  background-color: white;
+  color: #ff9e9e;
+  border: 2px solid #ff9e9e;
+  border-radius: 10px;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.3rem;
+  max-width: 185px;
+  cursor: pointer;
+}
+
+.songInfoAddFavorite:hover {
+  background-color: #ff9e9e;
+  color: white;
+  border-color: #ff9e9e;
+}
+
 .songInfoAddList:hover {
   color: white;
-  border-color: #77ffcc;
-  background-color: #77ffcc;
+  border-color: #abc8ff;
+  background-color: #abc8ff;
 }

--- a/src/components/music/SongInfoContent/SongInfoContent.module.css
+++ b/src/components/music/SongInfoContent/SongInfoContent.module.css
@@ -1,0 +1,56 @@
+.songInfoContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.songInfoContent > img {
+  box-shadow: 0px 0px 15px -5px #777777;
+  width: 40%;
+  height: fit-content;
+  min-width: 130px;
+  min-height: 130px;
+}
+
+.songInfoDetail {
+  width: 60%;
+  display: flex;
+  flex-direction: column;
+  margin-left: 2rem;
+}
+
+.songInfoDetail > * {
+  margin-top: 0.4rem;
+}
+
+.songInfoDetail > h2 {
+  font-size: 1.1rem;
+}
+
+.songInfoDetail > p {
+  font-size: 0.9rem;
+}
+
+.songInfoAudio {
+  width: 90%;
+}
+
+.songInfoAddList {
+  display: flex;
+  background-color: white;
+  color: #77ffcc;
+  border: 2px solid #77ffcc;
+  border-radius: 10px;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.3rem;
+  max-width: 185px;
+  cursor: pointer;
+}
+
+.songInfoAddList:hover {
+  color: white;
+  border-color: #77ffcc;
+  background-color: #77ffcc;
+}

--- a/src/components/music/SongInfoContent/SongInfoContent.test.tsx
+++ b/src/components/music/SongInfoContent/SongInfoContent.test.tsx
@@ -1,0 +1,49 @@
+import { Preview } from "@mui/icons-material";
+import { render, screen } from "@testing-library/react";
+import SongInfoContent from "./SongInfoContent";
+
+// SongAudioコンポーネントをモック
+jest.mock("../SongAudio/SongAudio", () => ({
+  __esModule: true,
+  default: ({ preview }: { preview?: string }) => (
+    <div data-testid="song-audio">
+      {preview ? `SongAudio with preview: ${preview}` : "SongAudio without preview"}
+    </div>
+  ),
+}));
+
+// CreateNewFolderIconをモック
+jest.mock("@mui/icons-material/CreateNewFolder", () => ({
+  __esModule: true,
+  default: () => <svg data-testid="create-new-folder-icon" />,
+}));
+
+describe("SongInfoContent", () => {
+  const testProps = {
+    title: "ALONES",
+    artist: "Aquatimez",
+    image: "example.jpeg",
+    preview: "https://example.com/test-preview.mp3",
+  };
+
+  const noPreviewProps = {
+    ...testProps,
+    preview: undefined,
+  };
+
+  test("受け取ったpropsを反映し、レンダリングされること", () => {
+    render(<SongInfoContent {...testProps} />);
+    expect(screen.getByText("ALONES")).toBeInTheDocument();
+    expect(screen.getByText("Aquatimez")).toBeInTheDocument();
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "ALONESのジャケット");
+    expect(screen.getByText("プレイリストに追加")).toBeInTheDocument();
+  });
+
+  test("previewがpropsで渡されなくても、レンダリングされること", () => {
+    render(<SongInfoContent {...noPreviewProps} />);
+    expect(screen.getByText("ALONES")).toBeInTheDocument();
+    expect(screen.getByText("Aquatimez")).toBeInTheDocument();
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "ALONESのジャケット");
+    expect(screen.getByText("プレイリストに追加")).toBeInTheDocument();
+  });
+});

--- a/src/components/music/SongInfoContent/SongInfoContent.tsx
+++ b/src/components/music/SongInfoContent/SongInfoContent.tsx
@@ -2,6 +2,7 @@ import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
 import Image from "next/image";
 import SongAudio from "../SongAudio/SongAudio";
 import styles from "./SongInfoContent.module.css";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 
 type SongInfoContentProps = {
   title: string;
@@ -10,11 +11,22 @@ type SongInfoContentProps = {
   preview?: string;
 };
 
-const SongInfoContent = ({ title, artist, image, preview }: SongInfoContentProps) => {
+const SongInfoContent = ({
+  title,
+  artist,
+  image,
+  preview,
+}: SongInfoContentProps) => {
   return (
     <div>
       <div className={styles.songInfoContent}>
-        <Image src={image} alt={`${title}のジャケット`} width={130} height={130} priority />
+        <Image
+          src={image}
+          alt={`${title}のジャケット`}
+          width={130}
+          height={130}
+          priority
+        />
         <div className={styles.songInfoDetail}>
           <h2>{title}</h2>
           <p>{artist}</p>
@@ -22,6 +34,10 @@ const SongInfoContent = ({ title, artist, image, preview }: SongInfoContentProps
             <SongAudio preview={preview} />
           </div>
           {/* FIXME: プレイリストに追加する処理を記述する必要があります。 */}
+          <div className={styles.songInfoAddFavorite}>
+            <FavoriteBorderIcon />
+            <p>お気に入りに追加</p>
+          </div>
           <div className={styles.songInfoAddList}>
             <CreateNewFolderIcon />
             <p>プレイリストに追加</p>

--- a/src/components/music/SongInfoContent/SongInfoContent.tsx
+++ b/src/components/music/SongInfoContent/SongInfoContent.tsx
@@ -1,0 +1,35 @@
+import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
+import Image from "next/image";
+import SongAudio from "../SongAudio/SongAudio";
+import styles from "./SongInfoContent.module.css";
+
+type SongInfoContentProps = {
+  title: string;
+  artist: string;
+  image: string;
+  preview?: string;
+};
+
+const SongInfoContent = ({ title, artist, image, preview }: SongInfoContentProps) => {
+  return (
+    <div>
+      <div className={styles.songInfoContent}>
+        <Image src={image} alt={`${title}のジャケット`} width={130} height={130} priority />
+        <div className={styles.songInfoDetail}>
+          <h2>{title}</h2>
+          <p>{artist}</p>
+          <div>
+            <SongAudio preview={preview} />
+          </div>
+          {/* FIXME: プレイリストに追加する処理を記述する必要があります。 */}
+          <div className={styles.songInfoAddList}>
+            <CreateNewFolderIcon />
+            <p>プレイリストに追加</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SongInfoContent;

--- a/src/components/music/SongInfoContent/SongInfoContent.tsx
+++ b/src/components/music/SongInfoContent/SongInfoContent.tsx
@@ -1,8 +1,8 @@
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import Image from "next/image";
 import SongAudio from "../SongAudio/SongAudio";
 import styles from "./SongInfoContent.module.css";
-import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 
 type SongInfoContentProps = {
   title: string;
@@ -11,22 +11,11 @@ type SongInfoContentProps = {
   preview?: string;
 };
 
-const SongInfoContent = ({
-  title,
-  artist,
-  image,
-  preview,
-}: SongInfoContentProps) => {
+const SongInfoContent = ({ title, artist, image, preview }: SongInfoContentProps) => {
   return (
     <div>
       <div className={styles.songInfoContent}>
-        <Image
-          src={image}
-          alt={`${title}のジャケット`}
-          width={130}
-          height={130}
-          priority
-        />
+        <Image src={image} alt={`${title}のジャケット`} width={130} height={130} priority />
         <div className={styles.songInfoDetail}>
           <h2>{title}</h2>
           <p>{artist}</p>

--- a/src/components/mypage/SongList/SongList.test.tsx
+++ b/src/components/mypage/SongList/SongList.test.tsx
@@ -19,19 +19,19 @@ const mockSong: DeezerSong = {
 
 describe("SongListコンポーネントのテスト", () => {
   test("楽曲がない場合、メッセージを表示すること", () => {
-    render(<SongList songs={[]} />);
+    render(<SongList songs={[]} errorMessage="お気に入り曲は登録されていません" />);
     expect(screen.getByText("お気に入り曲は登録されていません")).toBeInTheDocument();
   });
 
   test("楽曲が1つある場合、1つのSongListItemを表示すること", () => {
-    render(<SongList songs={[mockSong]} />);
+    render(<SongList songs={[mockSong]} errorMessage="お気に入り曲は登録されていません" />);
     expect(screen.getByText("分針を噛む")).toBeInTheDocument();
     expect(screen.getAllByRole("listitem")).toHaveLength(1);
   });
 
   test("複数の楽曲がある場合、複数のSongListItemを表示する", () => {
     const songs = [mockSong, { ...mockSong, id: 555, title: "勘鈍くて悔しいわ" }];
-    render(<SongList songs={songs} />);
+    render(<SongList songs={songs} errorMessage="お気に入り曲は登録されていません" />);
 
     expect(screen.getByText("分針を噛む")).toBeInTheDocument();
     expect(screen.getByText("勘鈍くて悔しいわ")).toBeInTheDocument();

--- a/src/components/mypage/SongList/SongList.tsx
+++ b/src/components/mypage/SongList/SongList.tsx
@@ -2,11 +2,17 @@ import type { DeezerSong } from "@/types/deezer";
 import SongListItem from "../SongListItem/SongListItem";
 import styles from "./SongList.module.css";
 
-const SongList = ({ songs }: { songs: DeezerSong[] }) => {
+const SongList = ({
+  songs,
+  errorMessage,
+}: {
+  songs: DeezerSong[];
+  errorMessage: string;
+}) => {
   return (
     <div className={styles.songList}>
       {songs.length === 0 ? (
-        <p className={styles.noSongsMessage}>お気に入り曲は登録されていません</p>
+        <p className={styles.noSongsMessage}>{errorMessage}</p>
       ) : (
         <ul>
           {songs.map((song: DeezerSong) => {

--- a/src/components/top/BreadList/BreadList.module.css
+++ b/src/components/top/BreadList/BreadList.module.css
@@ -2,10 +2,12 @@
   background-color: #c0ffe7;
   padding: 0.7rem 1rem;
   font-size: 0.8rem;
+  display: flex;
+  align-items: center;
 }
 
-.breadListGroup > span {
-  margin: 0 1rem;
+.breadListGroup span {
+  margin: 0 0.5rem;
 }
 
 .breadListTitle:hover {

--- a/src/components/top/SongContent/SongContent.test.tsx
+++ b/src/components/top/SongContent/SongContent.test.tsx
@@ -1,4 +1,4 @@
-import { DeezerNewSongDetail, type DeezerSong } from "@/types/deezer";
+import type { DeezerSong } from "@/types/deezer";
 import { render, screen } from "@testing-library/react";
 import SongContent from "./SongContent";
 
@@ -19,11 +19,12 @@ const mockSong: DeezerSong = {
 
 describe("SongContentの単体テスト", () => {
   test("受け取ったpropsを反映し、レンダリングされること", () => {
-    render(<SongContent song={mockSong} />);
+    render(<SongContent song={mockSong} url="music" />);
     const imgElement = screen.getByAltText("シンデレラのジャケット画像");
 
     expect(screen.getByText("シンデレラ")).toBeInTheDocument();
     expect(screen.getByText("サイダーガール")).toBeInTheDocument();
     expect(imgElement).toHaveAttribute("src", mockSong.cover_xl);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/music/1");
   });
 });

--- a/src/components/top/SongContent/SongContent.tsx
+++ b/src/components/top/SongContent/SongContent.tsx
@@ -1,21 +1,24 @@
 import type { DeezerSong } from "@/types/deezer";
 import Image from "next/image";
+import Link from "next/link";
 import styles from "./SongContent.module.css";
 
-const SongContent = ({ song }: { song: DeezerSong }) => {
+const SongContent = ({ song, url }: { song: DeezerSong; url: string }) => {
   return (
     // FIXME: 後でリンクにする必要があります。
-    <div className={styles.songInfo}>
-      <Image
-        src={song.cover_xl || song.album.cover_xl || ""}
-        alt={`${song.title}のジャケット画像`}
-        width={180}
-        height={180}
-        priority
-      />
-      <p>{song.artist.name}</p>
-      <p>{song.title}</p>
-    </div>
+    <Link href={`/${url}/${song.id}`}>
+      <div className={styles.songInfo}>
+        <Image
+          src={song.cover_xl || song.album.cover_xl || ""}
+          alt={`${song.title}のジャケット画像`}
+          width={180}
+          height={180}
+          priority
+        />
+        <p>{song.artist.name}</p>
+        <p>{song.title}</p>
+      </div>
+    </Link>
   );
 };
 

--- a/src/components/top/SongsGroup/SongsGroup.module.css
+++ b/src/components/top/SongsGroup/SongsGroup.module.css
@@ -18,3 +18,12 @@
 .newSongGroup > div:nth-child(3) > img {
   border: 5px solid rgb(193, 60, 60);
 }
+
+.newSongGroup img {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.newSongGroup img:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 20px #bababa;
+}

--- a/src/components/top/SongsGroup/SongsGroup.tsx
+++ b/src/components/top/SongsGroup/SongsGroup.tsx
@@ -2,11 +2,17 @@ import type { DeezerSong } from "@/types/deezer";
 import SongContent from "../SongContent/SongContent";
 import styles from "./SongsGroup.module.css";
 
-const SongsGroup = ({ songs }: { songs: { resultData: DeezerSong[] } }) => {
+const SongsGroup = ({
+  songs,
+  url,
+}: {
+  songs: { resultData: DeezerSong[] };
+  url: string;
+}) => {
   return (
     <div className={styles.newSongGroup}>
       {songs.resultData.map((song: DeezerSong) => {
-        return <SongContent song={song} key={song.id} />;
+        return <SongContent song={song} url={url} key={song.id} />;
       })}
     </div>
   );

--- a/src/types/deezer.ts
+++ b/src/types/deezer.ts
@@ -92,9 +92,12 @@ export type DeezerSong = {
   title: string;
   cover_xl?: string;
   release_date?: string;
+  preview?: string;
+  duration?: string;
   artist: {
     id: number;
     name: string;
+    picture_xl?: string;
   };
   album: {
     id: number;
@@ -120,5 +123,69 @@ export type GenreApiArtist = {
   picture_xl: string;
   radio: boolean;
   tracklist: string;
+  type: string;
+};
+
+// apiから返されるシングル情報
+export type SongInfo = {
+  id: number;
+  readable: boolean;
+  title: string;
+  title_short: string;
+  title_version: string;
+  link: string;
+  duration: number;
+  rank: number;
+  explicit_lyrics: boolean;
+  explicit_content_lyrics: number;
+  explicit_content_cover: number;
+  preview: string;
+};
+
+// apiから返されるcontributors情報
+export type ContributorsInfo = {
+  id: number;
+  name: string;
+  link: string;
+  share: string;
+  picture: string;
+  picture_small: string;
+  picture_medium: string;
+  picture_big: string;
+  picture_xl: string;
+  radio: boolean;
+  tracklist: string;
+  type: string;
+  role: string;
+};
+
+// apiから返されるアーティスト情報
+export type ArtistInfo = {
+  id: number;
+  name: string;
+  tracklist: string;
+  type: string;
+};
+
+// apiから返されるアルバム情報
+export type AlbumInfo = {
+  id: number;
+  title: string;
+  cover: string;
+  cover_small: string;
+  cover_medium: string;
+  cover_big: string;
+  cover_xl: string;
+  md5_image: string;
+  tracklist: string;
+  type: string;
+};
+
+// apiから返されるアーティストの人気楽曲(https://api.deezer.com/artist/:id/top)一曲
+export type FavoriteArtistSong = SongInfo & {
+  contributors: ContributorsInfo[];
+  md5_image: string;
+  artist: ArtistInfo;
+  album: AlbumInfo;
   type: string;
 };

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -56,7 +56,9 @@ export const getGenreArtist = async (genre: number) => {
 // songには楽曲のidを入力
 export const getSong = async (song: number) => {
   try {
-    const res = await fetch(`http://localhost:3000/api/songSearch?song=${song}`);
+    const res = await fetch(`http://localhost:3000/api/songSearch?song=${song}`, {
+      cache: "no-cache",
+    });
 
     if (!res.ok) {
       throw new Error("データが見つかりませんでした");
@@ -65,5 +67,26 @@ export const getSong = async (song: number) => {
     return await res.json();
   } catch (error) {
     console.log(error);
+  }
+};
+
+// アーティストの人気曲を取得する関数
+// artistIdにはアーティストのidを、limitには取得件数を入力
+export const getArtistSongs = async (artistId: number, limit: number) => {
+  try {
+    const res = await fetch(
+      `http://localhost:3000/api/artistFavoriteSongs?artistId=${artistId}&limit=${limit}`,
+      {
+        cache: "no-cache",
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error("データが見つかりませんでした");
+    }
+
+    return await res.json();
+  } catch (error) {
+    console.error(error);
   }
 };


### PR DESCRIPTION
## 概要 :bulb:
- 楽曲詳細ページ作成
- topページのシングルランキングに表示されている楽曲を詳細ページへのリンクに変更
<img width="1337" alt="スクリーンショット 2024-10-20 1 41 15" src="https://github.com/user-attachments/assets/83e51c93-9fd9-4a5b-8cc6-9236cd058e08">

## 観点 :eye:
#### 楽曲詳細ページ作成(/app/music/[id]/page.tsx)
- 楽曲のアーティストの人気曲をページで取得しています。

#### SongInfoContentコンポーネント作成
- 楽曲情報を表示しています。
- 単体テスト作成 OK。

#### SongAudioコンポーネント作成
- 楽曲を再生するコンポーネントです。
- 実際に視聴可能。

#### ImageTitleLinkコンポーネント作成
- 画像、サブタイトル、>をリンクで表示するコンポーネントです。
- 楽曲詳細ページではアーティストの情報を表示しています。
- 単体テスト作成 OK。

#### MusicContentTitleコンポーネント作成
- コンテンツのサブタイトルを表示するコンポーネントです。
- 単体テスト作成 OK。

#### アーティストの人気楽曲を取得するAPI作成(/api/artistFavoriteSong.ts)
- アーティストのidと取得件数を渡してdeezerから楽曲データを取得するapi作成
- 関数化してあります。

#### その他
- トップページスタイル調整
- トップページシングルランキングの楽曲を楽曲詳細ページへのリンクに変更(人気新着はアルバムなので別です。)
- パンくずリストのスタイルを調整
- biomeチェック一部変更（曲の再生に関するもので、変更せざるを得ませんでした。）

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:
- SongInfoContentコンポーネント単体テスト作成
- ImageTitleLinkコンポーネント単体テスト作成
- MusicContentTitleコンポーネント単体テスト作成

## 関連する Issue :memo:

## 補足情報 :notes:
- 変更点多くてすみません。（コード量は少ないはず、、、）
- 結構急ぎで作成したので、粗い箇所が多いかもしれません。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
