### PR TITLE
ハンバーガーメニューのアイコンをマイページのアイコンと統一

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -5,7 +5,7 @@ import LogoutIcon from "@mui/icons-material/Logout";
 import MusicNoteTwoToneIcon from "@mui/icons-material/MusicNoteTwoTone";
 import NoAccountsIcon from "@mui/icons-material/NoAccounts";
 import PeopleOutlineIcon from "@mui/icons-material/PeopleOutline";
-import PlayArrowTwoToneIcon from "@mui/icons-material/PlayArrowTwoTone";
+import HistoryIcon from "@mui/icons-material/History";
 import PlaylistPlayTwoToneIcon from "@mui/icons-material/PlaylistPlayTwoTone";
 import styles from "./page.module.css";
 
@@ -32,11 +32,14 @@ const MyPage = () => {
           subTitle="アーティスト"
           icon={<PeopleOutlineIcon fontSize="large" />}
         />
-        <MenuBox mainTitle="プレイリスト" icon={<PlaylistPlayTwoToneIcon fontSize="large" />} />
+        <MenuBox
+          mainTitle="プレイリスト"
+          icon={<PlaylistPlayTwoToneIcon fontSize="large" />}
+        />
         <MenuBox
           mainTitle="再生履歴"
           subTitle="（最新10件）"
-          icon={<PlayArrowTwoToneIcon fontSize="large" />}
+          icon={<HistoryIcon fontSize="large" />}
         />
       </div>
       <div className={styles.menuTitle}>
@@ -48,9 +51,15 @@ const MyPage = () => {
           subTitle="編集・確認"
           icon={<AccountBoxIcon fontSize="large" />}
         />
-        <MenuBox mainTitle="ログアウト" icon={<LogoutIcon fontSize="large" />} />
+        <MenuBox
+          mainTitle="ログアウト"
+          icon={<LogoutIcon fontSize="large" />}
+        />
         <div className={styles.gridRow}>
-          <MenuBox mainTitle="退会" icon={<NoAccountsIcon fontSize="large" />} />
+          <MenuBox
+            mainTitle="退会"
+            icon={<NoAccountsIcon fontSize="large" />}
+          />
         </div>
       </div>
     </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,11 +1,11 @@
 import MenuBox from "@/components/mypage/MenuBox/MenuBox";
 import BreadList from "@/components/top/BreadList/BreadList";
 import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import HistoryIcon from "@mui/icons-material/History";
 import LogoutIcon from "@mui/icons-material/Logout";
 import MusicNoteTwoToneIcon from "@mui/icons-material/MusicNoteTwoTone";
 import NoAccountsIcon from "@mui/icons-material/NoAccounts";
 import PeopleOutlineIcon from "@mui/icons-material/PeopleOutline";
-import HistoryIcon from "@mui/icons-material/History";
 import PlaylistPlayTwoToneIcon from "@mui/icons-material/PlaylistPlayTwoTone";
 import styles from "./page.module.css";
 
@@ -32,10 +32,7 @@ const MyPage = () => {
           subTitle="アーティスト"
           icon={<PeopleOutlineIcon fontSize="large" />}
         />
-        <MenuBox
-          mainTitle="プレイリスト"
-          icon={<PlaylistPlayTwoToneIcon fontSize="large" />}
-        />
+        <MenuBox mainTitle="プレイリスト" icon={<PlaylistPlayTwoToneIcon fontSize="large" />} />
         <MenuBox
           mainTitle="再生履歴"
           subTitle="（最新10件）"
@@ -51,15 +48,9 @@ const MyPage = () => {
           subTitle="編集・確認"
           icon={<AccountBoxIcon fontSize="large" />}
         />
-        <MenuBox
-          mainTitle="ログアウト"
-          icon={<LogoutIcon fontSize="large" />}
-        />
+        <MenuBox mainTitle="ログアウト" icon={<LogoutIcon fontSize="large" />} />
         <div className={styles.gridRow}>
-          <MenuBox
-            mainTitle="退会"
-            icon={<NoAccountsIcon fontSize="large" />}
-          />
+          <MenuBox mainTitle="退会" icon={<NoAccountsIcon fontSize="large" />} />
         </div>
       </div>
     </div>

--- a/src/components/frame/header/HamburgerMenu.module.css
+++ b/src/components/frame/header/HamburgerMenu.module.css
@@ -15,18 +15,18 @@
   top: 0;
   left: 0;
   z-index: calc(infinity);
-  width: 40vw;
-  height: 470px;
+  width: 80vw;
   border: 1px solid black;
   border-radius: 15px;
   background-color: white;
-  padding: 10px 15px;
-  font-size: 0.8rem;
+  padding: 15px 25px 25px 25px;
+
+  font-size: 1.2rem;
 }
 
 .hamburgerCloseIconMark {
   display: flex;
-  font-size: 30px;
+  font-size: 40px;
   width: 30px;
 }
 
@@ -53,8 +53,8 @@
 .hamburgerinList {
   list-style-type: none;
   display: flex;
-  margin-left: 15px;
-  margin-bottom: 10px;
+  margin-left: 25px;
+  margin-bottom: 13px;
   align-items: center;
 }
 

--- a/src/components/frame/header/HamburgerMenu.tsx
+++ b/src/components/frame/header/HamburgerMenu.tsx
@@ -1,6 +1,4 @@
 import { UseHamburgerOpen } from "@/hooks/header/useHamburgerOpen";
-import ContactPageIcon from "@mui/icons-material/ContactPage";
-import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import HeadphonesIcon from "@mui/icons-material/Headphones";
 import HistoryIcon from "@mui/icons-material/History";
 import HomeIcon from "@mui/icons-material/Home";
@@ -12,6 +10,9 @@ import PersonIcon from "@mui/icons-material/Person";
 import PlaylistPlayIcon from "@mui/icons-material/PlaylistPlay";
 import Image from "next/image";
 import styles from "./HamburgerMenu.module.css";
+import MusicNoteTwoToneIcon from "@mui/icons-material/MusicNoteTwoTone";
+import PeopleOutlineIcon from "@mui/icons-material/PeopleOutline";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
 
 export const HamburgerMenu = () => {
   const { openMenu, openMenuClick, hamburgerLink } = UseHamburgerOpen();
@@ -33,8 +34,8 @@ export const HamburgerMenu = () => {
                 <Image
                   src="/images/yaetunes_logo_transparent.png"
                   alt="header-logo"
-                  height={25}
-                  width={100}
+                  height={40}
+                  width={160}
                 />
               </div>
               <ul className={styles.hamburgerLists}>
@@ -43,7 +44,7 @@ export const HamburgerMenu = () => {
                   onClick={() => hamburgerLink("/")}
                   onKeyDown={() => hamburgerLink("/")}
                 >
-                  <HomeIcon />
+                  <HomeIcon fontSize="large" />
                   &nbsp;トップページ
                 </li>
                 <li
@@ -51,7 +52,7 @@ export const HamburgerMenu = () => {
                   onClick={() => hamburgerLink("/mypage")}
                   onKeyDown={() => hamburgerLink("/mypage")}
                 >
-                  <HeadphonesIcon />
+                  <HeadphonesIcon fontSize="large" />
                   &nbsp;マイページ
                 </li>
                 <ul>
@@ -60,7 +61,7 @@ export const HamburgerMenu = () => {
                     onClick={() => hamburgerLink("/mypage/playlist")}
                     onKeyDown={() => hamburgerLink("/mypage/playlist")}
                   >
-                    <PlaylistPlayIcon />
+                    <PlaylistPlayIcon fontSize="large" />
                     &nbsp;プレイリスト
                   </li>
                   <li
@@ -68,17 +69,15 @@ export const HamburgerMenu = () => {
                     onClick={() => hamburgerLink("/mypage/favoriteartist")}
                     onKeyDown={() => hamburgerLink("/mypage/favoriteartist")}
                   >
-                    <FavoriteBorderIcon />
-                    &nbsp;お気に入り
-                    <br />
-                    アーティスト
+                    <PeopleOutlineIcon fontSize="large" />
+                    &nbsp;お気に入りアーティスト
                   </li>
                   <li
                     className={styles.hamburgerinList}
                     onClick={() => hamburgerLink("/mypage/favoritesong")}
                     onKeyDown={() => hamburgerLink("/mypage/favoritesong")}
                   >
-                    <FavoriteBorderIcon />
+                    <MusicNoteTwoToneIcon fontSize="large" />
                     &nbsp;お気に入り楽曲
                   </li>
                   <li
@@ -86,13 +85,13 @@ export const HamburgerMenu = () => {
                     onClick={() => hamburgerLink("/mypage/history")}
                     onKeyDown={() => hamburgerLink("/mypage/history")}
                   >
-                    <HistoryIcon />
+                    <HistoryIcon fontSize="large" />
                     &nbsp;再生履歴
                   </li>
                 </ul>
                 <div className={styles.line} />
                 <li className={styles.hamburgerList}>
-                  <PersonIcon />
+                  <PersonIcon fontSize="large" />
                   &nbsp;ユーザー
                 </li>
                 {/* ログイン情報により記載内容変更 */}
@@ -101,7 +100,7 @@ export const HamburgerMenu = () => {
                   onClick={() => hamburgerLink("/user/login")}
                   onKeyDown={() => hamburgerLink("/user/login")}
                 >
-                  <LoginIcon />
+                  <LoginIcon fontSize="large" />
                   &nbsp;ログイン
                 </li>
                 <li
@@ -109,7 +108,7 @@ export const HamburgerMenu = () => {
                   onClick={() => hamburgerLink("/user/register")}
                   onKeyDown={() => hamburgerLink("/user/register")}
                 >
-                  <HowToRegIcon />
+                  <HowToRegIcon fontSize="large" />
                   &nbsp;新規登録
                 </li>
                 <li
@@ -117,7 +116,7 @@ export const HamburgerMenu = () => {
                   onClick={() => hamburgerLink("/user/logout")}
                   onKeyDown={() => hamburgerLink("/user/logout")}
                 >
-                  <LogoutIcon />
+                  <LogoutIcon fontSize="large" />
                   &nbsp;ログアウト
                 </li>
                 <li
@@ -125,7 +124,7 @@ export const HamburgerMenu = () => {
                   onClick={() => hamburgerLink("/user/[:id]")}
                   onKeyDown={() => hamburgerLink("/user/[:id]")}
                 >
-                  <ContactPageIcon />
+                  <AccountBoxIcon fontSize="large" />
                   &nbsp;アカウント情報
                 </li>
               </ul>

--- a/src/components/frame/header/HamburgerMenu.tsx
+++ b/src/components/frame/header/HamburgerMenu.tsx
@@ -1,4 +1,5 @@
 import { UseHamburgerOpen } from "@/hooks/header/useHamburgerOpen";
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
 import HeadphonesIcon from "@mui/icons-material/Headphones";
 import HistoryIcon from "@mui/icons-material/History";
 import HomeIcon from "@mui/icons-material/Home";
@@ -6,13 +7,12 @@ import HowToRegIcon from "@mui/icons-material/HowToReg";
 import LoginIcon from "@mui/icons-material/Login";
 import LogoutIcon from "@mui/icons-material/Logout";
 import MenuIcon from "@mui/icons-material/Menu";
+import MusicNoteTwoToneIcon from "@mui/icons-material/MusicNoteTwoTone";
+import PeopleOutlineIcon from "@mui/icons-material/PeopleOutline";
 import PersonIcon from "@mui/icons-material/Person";
 import PlaylistPlayIcon from "@mui/icons-material/PlaylistPlay";
 import Image from "next/image";
 import styles from "./HamburgerMenu.module.css";
-import MusicNoteTwoToneIcon from "@mui/icons-material/MusicNoteTwoTone";
-import PeopleOutlineIcon from "@mui/icons-material/PeopleOutline";
-import AccountBoxIcon from "@mui/icons-material/AccountBox";
 
 export const HamburgerMenu = () => {
   const { openMenu, openMenuClick, hamburgerLink } = UseHamburgerOpen();


### PR DESCRIPTION
## 概要 :bulb:
![image](https://github.com/user-attachments/assets/d2d7232b-8913-41c9-b650-29e3d08dd7bb)

- ハンバーガーメニューのサイズを変更しました。
- ハンバーガーメニューのアイコンと、マイページのアイコンを統一しました。

## 観点 :eye:


## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
