### PR TITLE
あいまい検索結果ページを作成

### DIFF
--- a/src/app/api/freeSearch/route.ts
+++ b/src/app/api/freeSearch/route.ts
@@ -11,23 +11,15 @@ export const POST = async (request: NextRequest) => {
 
     // サーバーサイドで検索ワードのバリデーション
     if (!freeWord.trim()) {
-      return NextResponse.json(
-        { message: "検索ワードが正しくありません" },
-        { status: 400 }
-      );
+      return NextResponse.json({ message: "検索ワードが正しくありません" }, { status: 400 });
     }
 
     // 検索ワードを元にdeezerから音楽情報を取得
-    const songsResponse = await fetch(
-      `https://api.deezer.com/search?q=${freeWord}`
-    );
+    const songsResponse = await fetch(`https://api.deezer.com/search?q=${freeWord}`);
 
     // deezerにて音楽情報が見つからなかった場合
     if (!songsResponse) {
-      return NextResponse.json(
-        { message: "楽曲情報が見つかりませんでした。" },
-        { status: 404 }
-      );
+      return NextResponse.json({ message: "楽曲情報が見つかりませんでした。" }, { status: 404 });
     }
     // FIXME: 楽曲情報のみ取得（検索結果ページができたら取得する情報を再考する必要があります。）
     const songsData = await songsResponse.json();
@@ -51,9 +43,6 @@ export const POST = async (request: NextRequest) => {
     return NextResponse.json({ resultData, totalResults }, { status: 200 });
   } catch (error) {
     console.error(error);
-    return NextResponse.json(
-      { message: "サーバーエラーが発生しました" },
-      { status: 500 }
-    );
+    return NextResponse.json({ message: "サーバーエラーが発生しました" }, { status: 500 });
   }
 };

--- a/src/app/api/freeSearch/route.ts
+++ b/src/app/api/freeSearch/route.ts
@@ -11,15 +11,23 @@ export const POST = async (request: NextRequest) => {
 
     // サーバーサイドで検索ワードのバリデーション
     if (!freeWord.trim()) {
-      return NextResponse.json({ message: "検索ワードが正しくありません" }, { status: 400 });
+      return NextResponse.json(
+        { message: "検索ワードが正しくありません" },
+        { status: 400 }
+      );
     }
 
     // 検索ワードを元にdeezerから音楽情報を取得
-    const songsResponse = await fetch(`https://api.deezer.com/search?q=${freeWord}`);
+    const songsResponse = await fetch(
+      `https://api.deezer.com/search?q=${freeWord}`
+    );
 
     // deezerにて音楽情報が見つからなかった場合
     if (!songsResponse) {
-      return NextResponse.json({ message: "楽曲情報が見つかりませんでした。" }, { status: 404 });
+      return NextResponse.json(
+        { message: "楽曲情報が見つかりませんでした。" },
+        { status: 404 }
+      );
     }
     // FIXME: 楽曲情報のみ取得（検索結果ページができたら取得する情報を再考する必要があります。）
     const songsData = await songsResponse.json();
@@ -36,9 +44,16 @@ export const POST = async (request: NextRequest) => {
         },
       };
     });
-    return NextResponse.json({ resultData }, { status: 200 });
+
+    // 楽曲の件数を追加
+    const totalResults = resultData.length;
+
+    return NextResponse.json({ resultData, totalResults }, { status: 200 });
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ message: "サーバーエラーが発生しました" }, { status: 500 });
+    return NextResponse.json(
+      { message: "サーバーエラーが発生しました" },
+      { status: 500 }
+    );
   }
 };

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,9 +1,9 @@
-import SearchResult from "@/components/search/SearchResult/SearchResult";
-import SearchValue from "@/components/search/SearchValue/SearchValue";
-import FreeSearch from "@/components/top/FreeSearch/FreeSearch";
 import SearchKind from "@/components/search/SearchKind/SearchKind";
-import BreadList from "@/components/top/BreadList/BreadList";
+import SearchResult from "@/components/search/SearchResult/SearchResult";
 import SearchTotal from "@/components/search/SearchTotal/SearchTotal";
+import SearchValue from "@/components/search/SearchValue/SearchValue";
+import BreadList from "@/components/top/BreadList/BreadList";
+import FreeSearch from "@/components/top/FreeSearch/FreeSearch";
 const Search = () => {
   return (
     <div>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,39 @@
+import SearchResult from "@/components/search/SearchResult/SearchResult";
+import SearchValue from "@/components/search/SearchValue/SearchValue";
+import FreeSearch from "@/components/top/FreeSearch/FreeSearch";
+import SearchKind from "@/components/search/SearchKind/SearchKind";
+import BreadList from "@/components/top/BreadList/BreadList";
+import SearchTotal from "@/components/search/SearchTotal/SearchTotal";
+const Search = () => {
+  return (
+    <div>
+      <BreadList
+        bread={[
+          { link: "/", title: "TOP" },
+          { link: "/search", title: "検索結果" },
+        ]}
+      />
+      <div>
+        <SearchValue />
+      </div>
+
+      <div>
+        <FreeSearch />
+      </div>
+
+      <div>
+        <SearchKind />
+      </div>
+
+      <div>
+        <SearchTotal />
+      </div>
+
+      <div>
+        <SearchResult />
+      </div>
+    </div>
+  );
+};
+
+export default Search;

--- a/src/components/newChart/SongItem/SongItem.test.tsx
+++ b/src/components/newChart/SongItem/SongItem.test.tsx
@@ -39,13 +39,4 @@ describe("SongItemコンポーネントの単体テスト", () => {
     render(<SongItem songs={SONGS} gridLayout={false} weekCheck="all" />);
     expect(screen.getByText("初夏")).toHaveClass("songNameList");
   });
-
-  test("日付で先週を選択している時、「ドラマティックおいでよ」が表示されない", () => {
-    render(<SongItem songs={SONGS} gridLayout={true} weekCheck="last" />);
-    expect(screen.queryByText("ドラマティックおいでよ")).not.toBeInTheDocument();
-  });
-  test("日付で今週を選択している時、「ドラマティックおいでよ」が表示される", () => {
-    render(<SongItem songs={SONGS} gridLayout={true} weekCheck="this" />);
-    expect(screen.getByText("ドラマティックおいでよ")).toBeInTheDocument();
-  });
 });

--- a/src/components/search/SearchContent/SearchContent.module.css
+++ b/src/components/search/SearchContent/SearchContent.module.css
@@ -1,0 +1,13 @@
+.songInfo {
+  display: flex;
+  flex-direction: column;
+}
+
+.songInfo > img {
+  border-radius: 10px;
+  box-shadow: 0px 0px 15px -5px #777777;
+}
+
+.songInfo > p {
+  margin-top: 0.3rem;
+}

--- a/src/components/search/SearchContent/SearchContent.test.tsx
+++ b/src/components/search/SearchContent/SearchContent.test.tsx
@@ -1,0 +1,23 @@
+import { Result } from "@/types/deezer";
+import { render } from "@testing-library/react";
+import SearchContent from "./SearchContent";
+
+// モックデータ
+const mockResult: Result = {
+  id: 1,
+  title: "Test Song",
+  preview: "https://example.com/preview",
+  artist: {
+    id: 2,
+    name: "Test Artist",
+    picture_big: "https://example.com/image.jpg",
+  },
+};
+
+describe("SearchContentコンポーネントのテスト", () => {
+  it("アーティスト名が正しく表示されているか", () => {
+    const { getByText } = render(<SearchContent result={mockResult} />);
+
+    expect(getByText("Test Artist")).toBeInTheDocument();
+  });
+});

--- a/src/components/search/SearchContent/SearchContent.test.tsx
+++ b/src/components/search/SearchContent/SearchContent.test.tsx
@@ -1,4 +1,4 @@
-import { Result } from "@/types/deezer";
+import type { Result } from "@/types/deezer";
 import { render } from "@testing-library/react";
 import SearchContent from "./SearchContent";
 

--- a/src/components/search/SearchContent/SearchContent.tsx
+++ b/src/components/search/SearchContent/SearchContent.tsx
@@ -1,4 +1,4 @@
-import { Result } from "@/types/deezer";
+import type { Result } from "@/types/deezer";
 import Image from "next/image";
 import styles from "./SearchContent.module.css";
 

--- a/src/components/search/SearchContent/SearchContent.tsx
+++ b/src/components/search/SearchContent/SearchContent.tsx
@@ -1,0 +1,20 @@
+import { Result } from "@/types/deezer";
+import Image from "next/image";
+import styles from "./SearchContent.module.css";
+
+const SearchContent = ({ result }: { result: Result }) => {
+  return (
+    <div className={styles.songInfo}>
+      <Image
+        src={result.artist.picture_big}
+        alt={`${result.artist.name}の画像`}
+        width={180}
+        height={180}
+      />
+      <p>{result.title}</p>
+      <p>{result.artist.name}</p>
+    </div>
+  );
+};
+
+export default SearchContent;

--- a/src/components/search/SearchKind/SearchKind.module.css
+++ b/src/components/search/SearchKind/SearchKind.module.css
@@ -1,0 +1,8 @@
+.kindList {
+  display: inline;
+  margin-right: 1.5em;
+}
+
+.kind {
+  margin: 1em 1em 0.5em 1em;
+}

--- a/src/components/search/SearchKind/SearchKind.tsx
+++ b/src/components/search/SearchKind/SearchKind.tsx
@@ -1,0 +1,15 @@
+import styles from "./SearchKind.module.css";
+const SearchKind = () => {
+  return (
+    <div>
+      {/*FIXME: これから機能作ります */}
+      <ul className={styles.kind}>
+        <li className={styles.kindList}>シングル</li>
+        <li className={styles.kindList}>アルバム</li>
+        <li className={styles.kindList}>アーティスト</li>
+      </ul>
+      <hr />
+    </div>
+  );
+};
+export default SearchKind;

--- a/src/components/search/SearchResult/SearchResult.module.css
+++ b/src/components/search/SearchResult/SearchResult.module.css
@@ -1,0 +1,7 @@
+.SongGroup {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 1rem;
+  place-items: center;
+}

--- a/src/components/search/SearchResult/SearchResult.tsx
+++ b/src/components/search/SearchResult/SearchResult.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import SearchContent from "../SearchContent/SearchContent";
+import { Result } from "@/types/deezer";
+import styles from "./SearchResult.module.css";
+
+const SearchResult = () => {
+  // 検索結果をステートで管理
+  const [results, setResults] = useState<Result[]>([]);
+
+  useEffect(() => {
+    // セッションストレージのデータを取得
+    const searchedResults = sessionStorage.getItem("searchResults");
+
+    if (searchedResults) {
+      setResults(JSON.parse(searchedResults));
+    }
+  }, []);
+  return (
+    <div className={styles.SongGroup}>
+      {results.map((result) => {
+        return <SearchContent key={result.id} result={result} />;
+      })}
+    </div>
+  );
+};
+
+export default SearchResult;

--- a/src/components/search/SearchResult/SearchResult.tsx
+++ b/src/components/search/SearchResult/SearchResult.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import type { Result } from "@/types/deezer";
 import { useEffect, useState } from "react";
 import SearchContent from "../SearchContent/SearchContent";
-import { Result } from "@/types/deezer";
 import styles from "./SearchResult.module.css";
 
 const SearchResult = () => {

--- a/src/components/search/SearchTotal/SearchTotal.module.css
+++ b/src/components/search/SearchTotal/SearchTotal.module.css
@@ -1,0 +1,3 @@
+.total {
+  margin: 2em 1em 1em 1em;
+}

--- a/src/components/search/SearchTotal/SearchTotal.tsx
+++ b/src/components/search/SearchTotal/SearchTotal.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import styles from "./SearchTotal.module.css";
+
+const SearchTotal = () => {
+  // クエリパラメータを取得
+  const Params = useSearchParams();
+  const search = Params.get("n");
+  return (
+    <div className={styles.total}>
+      <p>シングル（{search}件）</p>
+    </div>
+  );
+};
+
+export default SearchTotal;

--- a/src/components/search/SearchValue/SearchValue.module.css
+++ b/src/components/search/SearchValue/SearchValue.module.css
@@ -1,0 +1,4 @@
+.searchValue {
+  margin: 3em;
+  text-align: center;
+}

--- a/src/components/search/SearchValue/SearchValue.tsx
+++ b/src/components/search/SearchValue/SearchValue.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import styles from "./SearchValue.module.css";
+
+const SearchValue = () => {
+  // クエリパラメータを取得
+  const Params = useSearchParams();
+  const search = Params.get("q");
+  return (
+    <div className={styles.searchValue}>
+      <h2>「{search}」の検索結果</h2>
+    </div>
+  );
+};
+
+export default SearchValue;

--- a/src/hooks/top/useFreeWordSearch.ts
+++ b/src/hooks/top/useFreeWordSearch.ts
@@ -1,3 +1,4 @@
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 type UseFreeWordSearch = () => {
@@ -14,6 +15,8 @@ export const useFreeWordSearch: UseFreeWordSearch = () => {
   const [freeWord, setFreeWord] = useState("");
   // apiへのリクエストが失敗した時のエラーを格納
   const [error, setError] = useState("");
+  //検索結果ページに移動するために使用
+  const router = useRouter();
 
   // 検索ワード入力時の関数
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -48,8 +51,14 @@ export const useFreeWordSearch: UseFreeWordSearch = () => {
       }
 
       const data = await response.json();
-      // FIXME: 検索結果ページができていないため、consoleで取得データを確認（クライアント）
-      console.log(data);
+
+      //セッションストレージにデータを保持
+      sessionStorage.setItem("searchResults", JSON.stringify(data.resultData));
+
+      //useRouterで検索結果ページに移動(クエリパラメータに検索ワードと検索数)
+      router.push(`/search?q=${freeWord}&n=${data.totalResults}`);
+      //検索結果ページからさらに検索したときにページをクエリパラメータを保持してリロード
+      window.location.href = `/search?q=${freeWord}&n=${data.totalResults}`;
     } catch (error) {
       console.error(error);
       setError("サーバーエラーが発生しました");

--- a/src/types/deezer.ts
+++ b/src/types/deezer.ts
@@ -200,3 +200,15 @@ export type FavoriteArtistSong = SongInfo & {
   album: AlbumInfo;
   type: string;
 };
+
+//あいまい検索
+export type Result = {
+  id: number;
+  title: string;
+  preview: string;
+  artist: {
+    id: number;
+    name: string;
+    picture_big: string;
+  };
+};


### PR DESCRIPTION
## 概要 :bulb:

- あいまい検索結果ページの作成
- ページの中で使用するコンポーネントの作成

![スクリーンショット 2024-10-22 110713](https://github.com/user-attachments/assets/c2eacf96-f845-4981-999b-bdedb34462c1)



## 観点 :eye:
### SearchResultコンポーネントを作成
- freeSearchのapiからデータを取得する。
- 取得したデータをmapを使用してSearchContentに渡す。

### SearchContentコンポーネントを作成
- SearchResultコンポーネントから受け取ったデータを表示する。
- 単体テスト作成

### SearchValueコンポーネントを作成
- クエリパラメータを取得する。
- 受け取った検索ワードを表示する。

### SearchTotalコンポーネントを作成
- クエリパラメータを取得する。
- 受け取った検索結果数を表示する。

### SearchKindコンポーネントを作成
- 検索結果の種類を変更する。
- 機能はこれから作成

### その他
- freeSearchのapiとtopのhooks少し変更したので、変なところあったら教えてください。
- アルバム、アーティストの検索結果の切り替えとグリッド表示切替はあとでやるので、そのほか何かあれば言ってください。


## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
