### PR TITLE
アルバム詳細ページ作成(収録曲情報以外)

### DIFF
--- a/src/app/album/[id]/page.module.css
+++ b/src/app/album/[id]/page.module.css
@@ -1,0 +1,13 @@
+.albumPageContent {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.albumDetailContent,
+.albumSongsContent,
+.artistInfoLinkContent,
+.artistFavoriteSongsContent {
+  padding: 2rem 0;
+  border-bottom: 2px solid #c7c7c7;
+}

--- a/src/app/album/[id]/page.tsx
+++ b/src/app/album/[id]/page.tsx
@@ -1,0 +1,61 @@
+import AlbumInfo from "@/components/music/AlbumInfo/AlbumInfo";
+import ImageTitleLink from "@/components/music/ImageTitleLink/ImageTitleLink";
+import MusicContentTitle from "@/components/music/MusicContentTitle/MusicContentTitle";
+import SongList from "@/components/mypage/SongList/SongList";
+import BreadList from "@/components/top/BreadList/BreadList";
+import { getAlbum, getArtistSongs } from "@/utils/apiFunc";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import styles from "./page.module.css";
+
+type AlbumPageProps = {
+  params: { id: string };
+  searchParams: ReadonlyURLSearchParams;
+};
+
+const AlbumPage = async ({ params }: AlbumPageProps) => {
+  // クエリパラメーターからアルバムidを取得
+  const { id } = params;
+
+  // 取得したidのアルバム情報を取得
+  const { resultData } = await getAlbum(Number(id));
+
+  // 上記で取得したアーティストIDからアーティストの人気楽曲を最大4件取得
+  const artistSongs = await getArtistSongs(resultData.artist.id, 4);
+  return (
+    <>
+      <BreadList
+        bread={[
+          { link: "/", title: "TOP" },
+          { link: "/album/1", title: "アルバム詳細" },
+        ]}
+      />
+
+      <div className={styles.albumPageContent}>
+        <div className={styles.albumDetailContent}>
+          <AlbumInfo
+            image={resultData.cover_xl}
+            title={resultData.title}
+            artist={resultData.artist.name}
+            nb_tracks={resultData.nb_tracks}
+          />
+        </div>
+        {/* ここにアルバム収録曲一覧を表示します。 */}
+        <div className={styles.albumSongsContent} />
+        <div className={styles.artistInfoLinkContent}>
+          <MusicContentTitle title="アーティスト情報" />
+          <ImageTitleLink
+            url={`/artist/${resultData.artist.id}`}
+            name={resultData.artist.name}
+            image={resultData.artist.picture_xl}
+          />
+        </div>
+        <div className={styles.artistFavoriteSongsContent}>
+          <MusicContentTitle title="人気楽曲" />
+          <SongList songs={artistSongs.resultData} errorMessage="人気楽曲を取得できませんでした" />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AlbumPage;

--- a/src/app/api/albumSearch/route.ts
+++ b/src/app/api/albumSearch/route.ts
@@ -1,0 +1,45 @@
+import type { AlbumSong } from "@/types/deezer";
+import { duration } from "@mui/material";
+import { type NextRequest, NextResponse } from "next/server";
+
+// NOTE: 楽曲idからアルバム情報を取得して、DeezerAlbumの方に合わせたデータを返すAPI
+export const GET = async (request: NextRequest) => {
+  try {
+    const { searchParams } = request.nextUrl;
+    const album = searchParams.get("album");
+
+    const getAlbum = await fetch(`https://api.deezer.com/album/${album}`);
+
+    if (!getAlbum) {
+      return NextResponse.json({ message: "アルバム情報が見つかりませんでした" }, { status: 404 });
+    }
+
+    const albumData = await getAlbum.json();
+    const albumSongs = albumData.tracks.data.map((song: AlbumSong) => {
+      return {
+        id: song.id,
+        title: song.title ?? "title",
+        duration: song.duration ?? "不明",
+        preview: song.preview,
+        cover_xl: song.album.cover_xl ?? "/images/defaultsong.png",
+      };
+    });
+
+    const resultData = {
+      id: albumData.id,
+      title: albumData.title ?? "title",
+      cover_xl: albumData.cover_xl ?? "/images/defaultsong.png",
+      nb_tracks: albumData.nb_tracks ?? "不明",
+      artist: {
+        id: albumData.artist.id,
+        name: albumData.artist.name ?? "artist",
+        picture_xl: albumData.artist.picture_xl ?? "/images/defaultsong.png",
+      },
+      albumSongs,
+    };
+    return NextResponse.json({ resultData }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラーが発生しました" }, { status: 500 });
+  }
+};

--- a/src/components/music/AlbumInfo/AlbumInfo.module.css
+++ b/src/components/music/AlbumInfo/AlbumInfo.module.css
@@ -31,10 +31,6 @@
   font-size: 0.9rem;
 }
 
-.albumInfoAudio {
-  width: 90%;
-}
-
 .albumInfoAddList {
   display: flex;
   background-color: white;

--- a/src/components/music/AlbumInfo/AlbumInfo.module.css
+++ b/src/components/music/AlbumInfo/AlbumInfo.module.css
@@ -1,0 +1,76 @@
+.albumInfoContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.albumInfoContent > img {
+  box-shadow: 0px 0px 15px -5px #777777;
+  width: 40%;
+  height: fit-content;
+  min-width: 130px;
+  min-height: 130px;
+}
+
+.albumInfoDetail {
+  width: 60%;
+  display: flex;
+  flex-direction: column;
+  margin-left: 2rem;
+}
+
+.albumInfoDetail > * {
+  margin-top: 0.4rem;
+}
+
+.albumInfoDetail > h2 {
+  font-size: 1.1rem;
+}
+
+.albumInfoDetail > p {
+  font-size: 0.9rem;
+}
+
+.albumInfoAudio {
+  width: 90%;
+}
+
+.albumInfoAddList {
+  display: flex;
+  background-color: white;
+  color: #abc8ff;
+  border: 2px solid #abc8ff;
+  border-radius: 10px;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.3rem;
+  max-width: 185px;
+  cursor: pointer;
+}
+
+.albumInfoAddFavorite {
+  display: flex;
+  background-color: white;
+  color: #ff9e9e;
+  border: 2px solid #ff9e9e;
+  border-radius: 10px;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.3rem;
+  max-width: 185px;
+  cursor: pointer;
+}
+
+.albumInfoAddFavorite:hover {
+  background-color: #ff9e9e;
+  color: white;
+  border-color: #ff9e9e;
+}
+
+.albumInfoAddList:hover {
+  color: white;
+  border-color: #abc8ff;
+  background-color: #abc8ff;
+}

--- a/src/components/music/AlbumInfo/AlbumInfo.test.tsx
+++ b/src/components/music/AlbumInfo/AlbumInfo.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import AlbumInfo from "./AlbumInfo";
+
+describe("AlbumInfoコンポーネント単体テスト", () => {
+  test("受け取ったpropsを反映し、レンダリングされること", () => {
+    render(<AlbumInfo image="example.jpg" title="IとU" artist="杉本" nb_tracks={10} />);
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "IとUのジャケット");
+    expect(screen.getByText("杉本")).toBeInTheDocument();
+    expect(screen.getByText("IとU")).toBeInTheDocument();
+    expect(screen.getByText("10曲")).toBeInTheDocument();
+  });
+});

--- a/src/components/music/AlbumInfo/AlbumInfo.tsx
+++ b/src/components/music/AlbumInfo/AlbumInfo.tsx
@@ -1,0 +1,37 @@
+import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import Image from "next/image";
+import styles from "./AlbumInfo.module.css";
+
+type AlbumInfoProps = {
+  title: string;
+  artist: string;
+  image: string;
+  nb_tracks: number;
+};
+
+const AlbumInfo = ({ image, title, artist, nb_tracks }: AlbumInfoProps) => {
+  return (
+    <div>
+      <div className={styles.albumInfoContent}>
+        <Image src={image} alt={`${title}のジャケット`} width={130} height={130} priority />
+        <div className={styles.albumInfoDetail}>
+          <h2>{title}</h2>
+          <p>{artist}</p>
+          <p>{nb_tracks}曲</p>
+          {/* FIXME: プレイリストに追加する処理を記述する必要があります。 */}
+          <div className={styles.albumInfoAddFavorite}>
+            <FavoriteBorderIcon />
+            <p>お気に入りに追加</p>
+          </div>
+          <div className={styles.albumInfoAddList}>
+            <CreateNewFolderIcon />
+            <p>プレイリストに追加</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AlbumInfo;

--- a/src/components/music/SongInfoContent/SongInfoContent.module.css
+++ b/src/components/music/SongInfoContent/SongInfoContent.module.css
@@ -31,10 +31,6 @@
   font-size: 0.9rem;
 }
 
-.songInfoAudio {
-  width: 90%;
-}
-
 .songInfoAddList {
   display: flex;
   background-color: white;

--- a/src/components/newChart/SongItem/SongItem.tsx
+++ b/src/components/newChart/SongItem/SongItem.tsx
@@ -3,6 +3,7 @@
 import type { DeezerChartSong } from "@/types/deezer";
 import { getMondayOfThisWeek } from "@/utils/getMonday";
 import Image from "next/image";
+import Link from "next/link";
 import styles from "./SongItem.module.css";
 
 export const SongItem = ({
@@ -34,41 +35,45 @@ export const SongItem = ({
       {gridLayout ? (
         <div className={styles.songItemsGridWrapper}>
           {songs.map((song) => (
-            <div key={song.id} className={styles.songItemGridWrapper}>
-              <Image
-                src={song.cover_xl}
-                alt=""
-                height={160}
-                width={160}
-                className={styles.songImageGrid}
-              />
-              <p className={styles.songNameGrid}>
-                {song.title.length <= 15 ? song.title : `${song.title.slice(0, 14)}...`}
-              </p>
-              <p className={styles.artistNameGrid}>
-                {song.artist.name.length <= 15
-                  ? song.artist.name
-                  : `${song.artist.name.slice(0, 14)}...`}
-              </p>
-            </div>
+            <Link href={`/album/${song.id}`} key={song.id}>
+              <div className={styles.songItemGridWrapper}>
+                <Image
+                  src={song.cover_xl}
+                  alt=""
+                  height={160}
+                  width={160}
+                  className={styles.songImageGrid}
+                />
+                <p className={styles.songNameGrid}>
+                  {song.title.length <= 15 ? song.title : `${song.title.slice(0, 14)}...`}
+                </p>
+                <p className={styles.artistNameGrid}>
+                  {song.artist.name.length <= 15
+                    ? song.artist.name
+                    : `${song.artist.name.slice(0, 14)}...`}
+                </p>
+              </div>
+            </Link>
           ))}
         </div>
       ) : (
         <div className={styles.songItemsListWrapper}>
           {songs.map((song) => (
-            <div key={song.id} className={styles.songItemListWrapper}>
-              <Image
-                src={song.cover_xl}
-                alt=""
-                height={70}
-                width={70}
-                className={styles.songImageList}
-              />
-              <div className={styles.nameList}>
-                <p className={styles.songNameList}>{song.title}</p>
-                <p className={styles.artistNameList}>{song.artist.name}</p>
+            <Link href={`/album/${song.id}`} key={song.id}>
+              <div className={styles.songItemListWrapper}>
+                <Image
+                  src={song.cover_xl}
+                  alt=""
+                  height={70}
+                  width={70}
+                  className={styles.songImageList}
+                />
+                <div className={styles.nameList}>
+                  <p className={styles.songNameList}>{song.title}</p>
+                  <p className={styles.artistNameList}>{song.artist.name}</p>
+                </div>
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/src/components/rankingChart/SongItem/SongItem.tsx
+++ b/src/components/rankingChart/SongItem/SongItem.tsx
@@ -2,6 +2,7 @@
 
 import type { DeezerSong } from "@/types/deezer";
 import Image from "next/image";
+import Link from "next/link";
 import styles from "./SongItem.module.css";
 
 export const SongItem = ({
@@ -16,67 +17,71 @@ export const SongItem = ({
       {gridLayout ? (
         <div className={styles.songItemsGridWrapper}>
           {songs.map((song, index) => (
-            <div key={song.id} className={styles.songItemGridWrapper}>
-              <p
-                className={
-                  index + 1 === 1
-                    ? styles.firstRankGrid
-                    : index + 1 === 2
-                      ? styles.secondRankGrid
-                      : index + 1 === 3
-                        ? styles.thirdRankGrid
-                        : styles.otherRankGrid
-                }
-              >
-                {index + 1}
-              </p>
-              <Image
-                src={song.cover_xl || song.album.cover_xl || ""}
-                alt=""
-                height={160}
-                width={160}
-                className={styles.songImageGrid}
-              />
-              <p className={styles.songNameGrid}>
-                {song.title.length <= 15 ? song.title : `${song.title.slice(0, 14)}...`}
-              </p>
-              <p className={styles.artistNameGrid}>
-                {song.artist.name.length <= 15
-                  ? song.artist.name
-                  : `${song.artist.name.slice(0, 14)}...`}
-              </p>
-            </div>
+            <Link href={`/music/${song.id}`} key={song.id}>
+              <div className={styles.songItemGridWrapper}>
+                <p
+                  className={
+                    index + 1 === 1
+                      ? styles.firstRankGrid
+                      : index + 1 === 2
+                        ? styles.secondRankGrid
+                        : index + 1 === 3
+                          ? styles.thirdRankGrid
+                          : styles.otherRankGrid
+                  }
+                >
+                  {index + 1}
+                </p>
+                <Image
+                  src={song.cover_xl || song.album.cover_xl || ""}
+                  alt=""
+                  height={160}
+                  width={160}
+                  className={styles.songImageGrid}
+                />
+                <p className={styles.songNameGrid}>
+                  {song.title.length <= 15 ? song.title : `${song.title.slice(0, 14)}...`}
+                </p>
+                <p className={styles.artistNameGrid}>
+                  {song.artist.name.length <= 15
+                    ? song.artist.name
+                    : `${song.artist.name.slice(0, 14)}...`}
+                </p>
+              </div>
+            </Link>
           ))}
         </div>
       ) : (
         <div className={styles.songItemsListWrapper}>
           {songs.map((song, index) => (
-            <div key={song.id} className={styles.songItemListWrapper}>
-              <p
-                className={
-                  index + 1 === 1
-                    ? styles.firstRankList
-                    : index + 1 === 2
-                      ? styles.secondRankList
-                      : index + 1 === 3
-                        ? styles.thirdRankList
-                        : styles.otherRankList
-                }
-              >
-                {index + 1}
-              </p>
-              <Image
-                src={song.cover_xl || song.album.cover_xl || ""}
-                alt=""
-                height={70}
-                width={70}
-                className={styles.songImageList}
-              />
-              <div className={styles.nameList}>
-                <p className={styles.songNameList}>{song.title}</p>
-                <p className={styles.artistNameList}>{song.artist.name}</p>
+            <Link href={`/music/${song.id}`} key={song.id}>
+              <div className={styles.songItemListWrapper}>
+                <p
+                  className={
+                    index + 1 === 1
+                      ? styles.firstRankList
+                      : index + 1 === 2
+                        ? styles.secondRankList
+                        : index + 1 === 3
+                          ? styles.thirdRankList
+                          : styles.otherRankList
+                  }
+                >
+                  {index + 1}
+                </p>
+                <Image
+                  src={song.cover_xl || song.album.cover_xl || ""}
+                  alt=""
+                  height={70}
+                  width={70}
+                  className={styles.songImageList}
+                />
+                <div className={styles.nameList}>
+                  <p className={styles.songNameList}>{song.title}</p>
+                  <p className={styles.artistNameList}>{song.artist.name}</p>
+                </div>
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/src/types/deezer.ts
+++ b/src/types/deezer.ts
@@ -200,3 +200,14 @@ export type FavoriteArtistSong = SongInfo & {
   album: AlbumInfo;
   type: string;
 };
+
+// アルバム1曲の型
+export type AlbumSong = {
+  id: number;
+  title: string;
+  duration: number;
+  preview: string;
+  album: {
+    cover_xl: string;
+  };
+};

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -13,7 +13,7 @@ export const getNewSongs = async (limit: number) => {
     const result = await res.json();
 
     if (result.resultData.length < limit && limit === 4) {
-      for (let i = 0; i < limit - result.resultData.length; i++) {
+      for (let i = 0; i <= limit - result.resultData.length; i++) {
         result.resultData.push({
           id: 0,
           title: "title",
@@ -47,19 +47,21 @@ export const getRankSingleSongs = async (limit: number) => {
     const result = await res.json();
 
     if (result.resultData.length < limit && limit === 4) {
-      result.resultData.push({
-        id: 0,
-        title: "title",
-        artist: {
-          id: 1,
-          name: "artist",
-        },
-        album: {
-          id: 1,
-          title: "album",
-          cover_xl: "/images/defaultsong.png",
-        },
-      });
+      for (let i = 0; i <= limit - result.resultData.length; i++) {
+        result.resultData.push({
+          id: 0,
+          title: "title",
+          artist: {
+            id: 1,
+            name: "artist",
+          },
+          album: {
+            id: 1,
+            title: "album",
+            cover_xl: "/images/defaultsong.png",
+          },
+        });
+      }
     }
 
     return result;

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -142,3 +142,21 @@ export const getArtist = async (artist: number) => {
     console.error(error);
   }
 };
+
+// アルバムidからアルバム情報を取得する関数
+// albumにはアルバムidを入力
+export const getAlbum = async (album: number) => {
+  try {
+    const res = await fetch(`http://localhost:3000/api/albumSearch?album=${album}`, {
+      cache: "no-cache",
+    });
+
+    if (!res.ok) {
+      throw new Error("データが見つかりませんでした");
+    }
+
+    return await res.json();
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
## 概要 :bulb:
- アルバム詳細ページ作成
- アルバム情報を取得するapi作成
- 一覧ページのアルバムや楽曲をリンクに変更
<img width="430" alt="スクリーンショット 2024-10-23 11 59 53" src="https://github.com/user-attachments/assets/2f2c9ce7-2383-4ac7-bfb9-519f07ee57b8">


## 観点 :eye:
#### アルバム詳細ページ作成 /album/id
- アルバム情報を表示するコンポーネント（components/music/AlbumInfo）を作成し、ページ上部に配置しています。
- それ以外は既存のコンポーネントを使用しています。

#### アルバム情報取得のためのAPI作成
- deezer apiよりidに基づくアルバム情報を取得するルートハンドラーを作成

#### 一覧ページの楽曲情報をリンクに変更
- シングルランキングページおよび、人気新着アルバムページの楽曲情報を詳細ページへのリンクへと変更しました。

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [x] 特定の個人・団体名などを使用していないか
- [x] 接続情報など秘密情報が含まれていないか
- [x] ログに個人情報等が含まれていないか
- [x] ドメインは example.com を使用しているか

## テスト :test_tube:
- AlbumInfoコンポーネント単体テスト作成

## 関連する Issue :memo:


## 補足情報 :notes:


## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
