### PR TITLE
アルバム詳細ページ-収録楽曲一覧表示

### DIFF
--- a/src/app/(top)/page.tsx
+++ b/src/app/(top)/page.tsx
@@ -30,7 +30,7 @@ const TopPage = async () => {
         <div className={styles.newSongsContent}>
           <div className={styles.contentTitleGroup}>
             <ContentTitle title="人気新着アルバム" />
-            <LinkButton label="もっと見る >" />
+            <LinkButton label="もっと見る >" url="newarrival" />
           </div>
           <SongsGroup songs={newSongs} url="album" />
         </div>
@@ -38,7 +38,7 @@ const TopPage = async () => {
         <div className={styles.newSongsContent}>
           <div className={styles.contentTitleGroup}>
             <ContentTitle title="シングルランキング" />
-            <LinkButton label="もっと見る >" />
+            <LinkButton label="もっと見る >" url="/ranking" />
           </div>
           <SongsGroup songs={singleSongs} url="music" />
         </div>

--- a/src/app/album/[id]/page.tsx
+++ b/src/app/album/[id]/page.tsx
@@ -1,4 +1,5 @@
 import AlbumInfo from "@/components/music/AlbumInfo/AlbumInfo";
+import AlbumSingles from "@/components/music/AlbumSingles/AlbumSingles";
 import ImageTitleLink from "@/components/music/ImageTitleLink/ImageTitleLink";
 import MusicContentTitle from "@/components/music/MusicContentTitle/MusicContentTitle";
 import SongList from "@/components/mypage/SongList/SongList";
@@ -21,12 +22,13 @@ const AlbumPage = async ({ params }: AlbumPageProps) => {
 
   // 上記で取得したアーティストIDからアーティストの人気楽曲を最大4件取得
   const artistSongs = await getArtistSongs(resultData.artist.id, 4);
+
   return (
     <>
       <BreadList
         bread={[
           { link: "/", title: "TOP" },
-          { link: "/album/1", title: "アルバム詳細" },
+          { link: `/album/${resultData.id}`, title: "アルバム詳細" },
         ]}
       />
 
@@ -39,8 +41,10 @@ const AlbumPage = async ({ params }: AlbumPageProps) => {
             nb_tracks={resultData.nb_tracks}
           />
         </div>
-        {/* ここにアルバム収録曲一覧を表示します。 */}
-        <div className={styles.albumSongsContent} />
+        <div className={styles.albumSongsContent}>
+          <MusicContentTitle title="収録楽曲" />
+          <AlbumSingles singles={resultData.albumSongs} />
+        </div>
         <div className={styles.artistInfoLinkContent}>
           <MusicContentTitle title="アーティスト情報" />
           <ImageTitleLink

--- a/src/app/music/[id]/page.tsx
+++ b/src/app/music/[id]/page.tsx
@@ -27,7 +27,7 @@ const SongPage = async ({ params }: SongPageProps) => {
       <BreadList
         bread={[
           { link: "/", title: "TOP" },
-          { link: "/music/1", title: "楽曲詳細" },
+          { link: `/music/${resSongData.id}`, title: "楽曲詳細" },
         ]}
       />
       <div className={styles.songPageContent}>

--- a/src/app/unexpected.module.css
+++ b/src/app/unexpected.module.css
@@ -1,6 +1,6 @@
 .unexpectedPage {
   padding: 2rem;
-  height: calc(100vh - 80px - 130px);
+  height: calc(100vh - 130px - 79px);
   background-color: #efefef;
 }
 
@@ -10,14 +10,14 @@
   justify-content: center;
   align-items: center;
   border-radius: 10px;
-  padding: 1rem;
   background-color: #efefef;
   text-align: center;
   line-height: 1.6;
+  font-size: 0.9rem;
 }
 
 .unexpectedContent > h1 {
-  font-size: 2rem;
+  font-size: 1.6rem;
   padding: 1rem;
 }
 

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
@@ -1,0 +1,19 @@
+.albumSingleContent {
+  display: flex;
+  align-items: center;
+}
+
+.albumSingleInfo {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-left: 1rem;
+}
+
+.albumSingleInfo > button {
+  background-color: white;
+  border: 1px solid #fc9aff;
+  border-radius: 5px;
+  padding: 0.2rem 0.6rem 0;
+}

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import AlbumSingleSong from "./AlbumSingleSong";
+
+describe("AlbumSingleSongコンポーネントの単体テスト", () => {
+  test("受け取ったpropsを反映し、正しくレンダリングすること", () => {
+    render(<AlbumSingleSong id={1} num={1} title="タイトル" preview="example.com" />);
+
+    expect(screen.getByText("01: タイトル")).toBeInTheDocument();
+    expect(screen.queryByText("プレビューが読み込めません")).not.toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/music/1");
+  });
+
+  test("previewがなかった場合に、その旨が表示されること", () => {
+    render(<AlbumSingleSong id={1} num={1} title="タイトル" preview="" />);
+    expect(screen.getByText("プレビューが読み込めません")).toBeInTheDocument();
+  });
+
+  test("numの値が9より大きい場合、先頭に0が付かないこと", () => {
+    render(<AlbumSingleSong id={1} num={15} title="タイトル" preview="example.com" />);
+    expect(screen.getByText("15: タイトル")).toBeInTheDocument();
+  });
+});

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
@@ -1,0 +1,46 @@
+import FavoriteIcon from "@mui/icons-material/Favorite";
+import Link from "next/link";
+import AlbumSingleSongAudio from "../AlbumSingleSongAudio/AlbumSingleSongAudio";
+import styles from "./AlbumSingleSong.module.css";
+
+type AlbumSingleSongProps = {
+  id: number;
+  num: number;
+  title: string;
+  preview: string;
+};
+
+const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
+  let displayNum = "";
+  if (num < 10) {
+    displayNum = `0${num}`;
+  } else {
+    displayNum = num.toString();
+  }
+
+  return (
+    <div className={styles.albumSingleContent}>
+      <AlbumSingleSongAudio preview={preview} />
+      <div className={styles.albumSingleInfo}>
+        <p>
+          <Link href={`/music/${id}`}>
+            {displayNum}: {title}
+          </Link>
+        </p>
+        <button type="button">
+          <FavoriteIcon
+            sx={{
+              fontSize: 16,
+              color: "#fc9aff",
+              cursor: "pointer",
+            }}
+            role="img"
+            aria-hidden="false"
+          />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AlbumSingleSong;

--- a/src/components/music/AlbumSingleSongAudio/AlbumSingleSongAudio.tsx
+++ b/src/components/music/AlbumSingleSongAudio/AlbumSingleSongAudio.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import PlayCircleIcon from "@mui/icons-material/PlayCircle";
+import StopCircleIcon from "@mui/icons-material/StopCircle";
+import { useRef, useState } from "react";
+
+const AlbumSingleSongAudio = ({ preview }: { preview: string }) => {
+  // 再生中かどうかstateで管理
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  // 再レンダリングさせたくないので、useRefでaudio要素を参照
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  // 曲を再生
+  const handlePlay = () => {
+    if (audioRef.current) {
+      audioRef.current.play();
+      setIsPlaying(true);
+    }
+  };
+
+  // 曲を一時停止
+  const handlePause = () => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      setIsPlaying(false);
+    }
+  };
+
+  return (
+    <>
+      <audio src={preview} ref={audioRef} />
+      <div>
+        {preview ? (
+          <>
+            <PlayCircleIcon
+              onClick={handlePlay}
+              sx={{
+                fontSize: 32,
+                color: !isPlaying ? "#77ffcc" : "#9a9a9a",
+                cursor: "pointer",
+              }}
+              style={{ pointerEvents: isPlaying ? "none" : "auto" }}
+            />
+            <StopCircleIcon
+              onClick={handlePause}
+              sx={{
+                fontSize: 32,
+                color: isPlaying ? "#77ffcc" : "#9a9a9a",
+                cursor: "pointer",
+              }}
+              style={{ pointerEvents: isPlaying ? "auto" : "none" }}
+            />
+          </>
+        ) : (
+          <p>プレビューが読み込めません</p>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default AlbumSingleSongAudio;

--- a/src/components/music/AlbumSingles/AlbumSingles.module.css
+++ b/src/components/music/AlbumSingles/AlbumSingles.module.css
@@ -1,0 +1,8 @@
+.albumSinglesContent {
+  margin-top: 1rem;
+}
+
+.albumSingleSong {
+  border-bottom: 1px solid rgb(203, 203, 203);
+  padding-bottom: 0.2rem;
+}

--- a/src/components/music/AlbumSingles/AlbumSingles.test.tsx
+++ b/src/components/music/AlbumSingles/AlbumSingles.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import AlbumSingles from "./AlbumSingles";
+
+const AlbumSingleProps = [
+  {
+    id: 1,
+    title: "テスト1",
+    duration: 180,
+    preview: "example1.com",
+    cover_xl: "example1.jpeg",
+  },
+  {
+    id: 2,
+    title: "テスト2",
+    duration: 190,
+    preview: "example2.com",
+    cover_xl: "example2.jpeg",
+  },
+  {
+    id: 3,
+    title: "テスト3",
+    duration: 200,
+    preview: "example2.com",
+    cover_xl: "example2.jpeg",
+  },
+];
+
+describe("AlbumSinglesコンポーネントの単体テスト", () => {
+  test("受け取ったpropsを反映し、3件ともレンダリングされること", () => {
+    render(<AlbumSingles singles={AlbumSingleProps} />);
+    expect(screen.getByText("01: テスト1")).toBeInTheDocument();
+    expect(screen.getByText("02: テスト2")).toBeInTheDocument();
+    expect(screen.getByText("03: テスト3")).toBeInTheDocument();
+  });
+});

--- a/src/components/music/AlbumSingles/AlbumSingles.tsx
+++ b/src/components/music/AlbumSingles/AlbumSingles.tsx
@@ -1,0 +1,30 @@
+import type { AlbumSingle } from "@/types/deezer";
+import AlbumSingleSong from "../AlbumSingleSong/AlbumSingleSong";
+import styles from "./AlbumSingles.module.css";
+
+type AlbumSong = {
+  id: number;
+  title: string;
+  preview: string;
+};
+
+const AlbumSingles = ({ singles }: { singles: AlbumSingle[] }) => {
+  return (
+    <div className={styles.albumSinglesContent}>
+      {singles.map((song: AlbumSong, index: number) => {
+        return (
+          <div key={song.id} className={styles.albumSingleSong}>
+            <AlbumSingleSong
+              id={song.id}
+              title={song.title}
+              preview={song.preview}
+              num={index + 1}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AlbumSingles;

--- a/src/components/top/FreeSearch/FreeSearch.module.css
+++ b/src/components/top/FreeSearch/FreeSearch.module.css
@@ -17,6 +17,7 @@
   background-color: white;
   margin-left: 0.2rem;
   border-radius: 9999px;
+  cursor: pointer;
 }
 
 .errorMessage {

--- a/src/components/top/LinkButton/LinkButton.test.tsx
+++ b/src/components/top/LinkButton/LinkButton.test.tsx
@@ -3,8 +3,9 @@ import LinkButton from "./LinkButton";
 
 describe("LinkButtonコンポーネント", () => {
   test("受け取ったpropsを反映し、レンダリングされること", () => {
-    render(<LinkButton label="もっと見る" />);
+    render(<LinkButton label="もっと見る" url="/" />);
     expect(screen.getByRole("button")).toBeInTheDocument();
     expect(screen.getByText("もっと見る")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/");
   });
 });

--- a/src/components/top/LinkButton/LinkButton.tsx
+++ b/src/components/top/LinkButton/LinkButton.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 import styles from "./LinkButton.module.css";
 
-const LinkButton = ({ label }: { label: string }) => {
+const LinkButton = ({ label, url }: { label: string; url: string }) => {
   return (
     // FIXME: 結果ページが実装出来次第、リンクを設定する
-    <Link href="/">
+    <Link href={url}>
       <button type="button" className={styles.linkButton}>
         {label}
       </button>

--- a/src/components/top/SongContent/SongContent.tsx
+++ b/src/components/top/SongContent/SongContent.tsx
@@ -15,8 +15,8 @@ const SongContent = ({ song, url }: { song: DeezerSong; url: string }) => {
           height={180}
           priority
         />
-        <p>{song.artist.name}</p>
         <p>{song.title}</p>
+        <p>{song.artist.name}</p>
       </div>
     </Link>
   );

--- a/src/types/deezer.ts
+++ b/src/types/deezer.ts
@@ -211,3 +211,12 @@ export type AlbumSong = {
     cover_xl: string;
   };
 };
+
+// アルバム詳細ページで表示される楽曲の型
+export type AlbumSingle = {
+  id: number;
+  title: string;
+  duration: number;
+  preview: string;
+  cover_xl: string;
+};


### PR DESCRIPTION
## 概要 :bulb:
- アルバム詳細ページにて、収録されている楽曲の一覧表示がされるようにしました。

## 観点 :eye:
#### AlbumSinglesコンポーネント作成 (/components/music/AlbumSingles)
- アルバムに含まれる楽曲一覧を表示するコンポーネントです。
- 簡単な単体テストを作成しています。
- 表示するデータはページコンポーネントで取得し、propsでこのコンポーネントに渡しています。

#### AlbumSingleSongコンポーネント作成(/components/music/AlbumSingleSong)
- アルバムに含まれる楽曲一覧の一つの曲の情報を表示するコンポーネントです。
- 簡単な単体テストを作成しています。
- 表示するデータは親コンポーネントのAlbumSinglesコンポーネントからpropsで渡しています。
- アイコンなどにはMUIを使用しています。

#### AlbumSingleSongAudioコンポーネント作成(/components/music/AlbumSingleSongAudio)
- アルバムに含まれる楽曲情報に付随する音楽再生ボタン、停止ボタンのコンポーネントです。
- 実際に楽曲を視聴することができます。
- 同時に複数再生できてしまう問題が残っています。(解消前にPRあげます。)

#### その他不具合修正
- 404ページのレイアウトが高さや横幅によって崩れる問題を修正
- 楽曲詳細ページのパンくずリストのリンクが常に/music/1であったものを動的にidが変わるよう修正
- トップページのフリーワード検索の虫眼鏡ボタンのホバー時にポインターが表示されるよう修正
- トップページの楽曲情報に表示されている楽曲名とアーティスト名の位置を交換

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:
各コンポーネントに対する簡単な単体テスト作成

## 関連する Issue :memo:

## 補足情報 :notes:
- アルバム詳細ページのが曲を複数再生できてしまう問題が残っています。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
