### PR TITLE
あいまい検索結果の画像をアルバム画像に変更

### DIFF
--- a/src/app/api/freeSearch/route.ts
+++ b/src/app/api/freeSearch/route.ts
@@ -34,6 +34,7 @@ export const POST = async (request: NextRequest) => {
           name: data.artist.name ?? "artist",
           picture_big: data.artist.picture_big ?? "/images/defaultsong.png",
         },
+        cover: data.album.cover_big ?? "/images/defaultsong.png",
       };
     });
 

--- a/src/components/search/SearchContent/SearchContent.module.css
+++ b/src/components/search/SearchContent/SearchContent.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
 }
 
-.songInfo > img {
+.songImage {
   border-radius: 10px;
   box-shadow: 0px 0px 15px -5px #777777;
   width: 100%;

--- a/src/components/search/SearchContent/SearchContent.test.tsx
+++ b/src/components/search/SearchContent/SearchContent.test.tsx
@@ -12,18 +12,23 @@ const mockResult: Result = {
     name: "Test Artist",
     picture_big: "https://example.com/image.jpg",
   },
+  cover: "https://example.com/cover.jpg",
 };
 
 describe("SearchContentコンポーネントのテスト", () => {
   test("アーティスト名が正しく表示されているか", () => {
-    const { getByText, getByAltText } = render(<SearchContent result={mockResult} url="url" />);
-
-    //srcとaltが正しく表示されているか
-    const image = getByAltText("Test Artistの画像");
-    expect(image).toHaveAttribute("src", "https://example.com/image.jpg");
-    expect(image).toHaveAttribute("alt", "Test Artistの画像");
+    const { getByText } = render(<SearchContent result={mockResult} url="url" />);
 
     //アーティスト名が表示されているか
     expect(getByText("Test Artist")).toBeInTheDocument();
+  });
+
+  test("曲の画像が正しく表示されているか", () => {
+    const { getByAltText } = render(<SearchContent result={mockResult} url="url" />);
+
+    //srcとaltが正しく表示されているか
+    const image = getByAltText("Test Artistの画像");
+    expect(image).toHaveAttribute("src", "https://example.com/cover.jpg");
+    expect(image).toHaveAttribute("alt", "Test Artistの画像");
   });
 });

--- a/src/components/search/SearchContent/SearchContent.tsx
+++ b/src/components/search/SearchContent/SearchContent.tsx
@@ -8,10 +8,11 @@ const SearchContent = ({ result, url }: { result: Result; url: string }) => {
     <div className={styles.songInfo}>
       <Link href={`/${url}/${result.id}`}>
         <Image
-          src={result.artist.picture_big}
+          src={result.cover}
           alt={`${result.artist.name}の画像`}
           width={180}
           height={180}
+          className={styles.songImage}
         />
       </Link>
       <p>{result.title}</p>

--- a/src/types/deezer.ts
+++ b/src/types/deezer.ts
@@ -211,6 +211,7 @@ export type Result = {
     name: string;
     picture_big: string;
   };
+  cover: string;
 };
 
 // アルバム1曲の型

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -172,6 +172,7 @@ export const getSearchSongs = async (freeWord: string) => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ freeWord }),
+      cache: "no-cache",
     });
 
     // 失敗した場合の処理


### PR DESCRIPTION
## 概要 :bulb:
アーティスト画像をアルバム画像に変更しました。

![スクリーンショット 2024-10-25 122219](https://github.com/user-attachments/assets/85d6141f-291d-4ba0-ab8b-bf26635b0274)


## 観点 :eye:
### api/freeSearchの修正
- アルバムの画像取得する部分を追加

### utils/apiFuncのgetSearchSongsの修正
- no-cacheを追記

### SearchContentのcssの修正
- スタイルが適応されてなかったので書き方を変更

### SearchContentのテストの修正
- アルバム画像を追加したのでモックデータの変更
- 一つのテストの中で二つのテストをしていたので二つに修正


## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [x] 特定の個人・団体名などを使用していないか
- [x] 接続情報など秘密情報が含まれていないか
- [x] ログに個人情報等が含まれていないか
- [x] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
