### PR TITLE
fix: アルバム詳細ページで複数楽曲を同時に視聴できてしまうトラブル対応

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -44,6 +44,17 @@
       "semicolons": "always",
       "arrowParentheses": "always"
     },
-    "globals": ["it", "test", "jest", "beforeEach", "afterEach", "describe", "expect", "React"]
+    "globals": [
+      "it",
+      "test",
+      "jest",
+      "beforeEach",
+      "afterEach",
+      "beforeAll",
+      "afterAll",
+      "describe",
+      "expect",
+      "React"
+    ]
   }
 }

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
@@ -1,6 +1,6 @@
+import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
 import { fireEvent, render, screen } from "@testing-library/react";
 import AlbumSingleSong from "./AlbumSingleSong";
-import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
 
 beforeAll(() => {
   jest.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => {
@@ -18,19 +18,12 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
   test("受け取ったpropsを反映し、正しくレンダリングすること", () => {
     render(
       <AlbumAudioProvider>
-        <AlbumSingleSong
-          id={1}
-          num={1}
-          title="タイトル"
-          preview="example.com"
-        />
-      </AlbumAudioProvider>
+        <AlbumSingleSong id={1} num={1} title="タイトル" preview="example.com" />
+      </AlbumAudioProvider>,
     );
 
     expect(screen.getByText("01: タイトル")).toBeInTheDocument();
-    expect(
-      screen.queryByText("プレビューが読み込めません")
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("プレビューが読み込めません")).not.toBeInTheDocument();
     expect(screen.getByRole("button")).toBeInTheDocument();
     expect(screen.getByRole("link")).toHaveAttribute("href", "/music/1");
   });
@@ -39,7 +32,7 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
     render(
       <AlbumAudioProvider>
         <AlbumSingleSong id={1} num={1} title="タイトル" preview="" />
-      </AlbumAudioProvider>
+      </AlbumAudioProvider>,
     );
     expect(screen.getByText("プレビューが読み込めません")).toBeInTheDocument();
   });
@@ -47,13 +40,8 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
   test("numの値が9より大きい場合、先頭に0が付かないこと", () => {
     render(
       <AlbumAudioProvider>
-        <AlbumSingleSong
-          id={1}
-          num={15}
-          title="タイトル"
-          preview="example.com"
-        />
-      </AlbumAudioProvider>
+        <AlbumSingleSong id={1} num={15} title="タイトル" preview="example.com" />
+      </AlbumAudioProvider>,
     );
     expect(screen.getByText("15: タイトル")).toBeInTheDocument();
   });
@@ -61,13 +49,8 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
   test("再生ボタンをクリックすると、playメソッドが呼び出されること", () => {
     render(
       <AlbumAudioProvider>
-        <AlbumSingleSong
-          id={1}
-          num={15}
-          title="タイトル"
-          preview="example.com"
-        />
-      </AlbumAudioProvider>
+        <AlbumSingleSong id={1} num={15} title="タイトル" preview="example.com" />
+      </AlbumAudioProvider>,
     );
 
     const playButton = screen.getByLabelText("playButton");
@@ -79,13 +62,8 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
   test("停止ボタンをクリックすると、stopメソッドが呼び出されること", () => {
     render(
       <AlbumAudioProvider>
-        <AlbumSingleSong
-          id={1}
-          num={15}
-          title="タイトル"
-          preview="example.com"
-        />
-      </AlbumAudioProvider>
+        <AlbumSingleSong id={1} num={15} title="タイトル" preview="example.com" />
+      </AlbumAudioProvider>,
     );
 
     const stopButton = screen.getByLabelText("stopButton");

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
@@ -1,23 +1,96 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import AlbumSingleSong from "./AlbumSingleSong";
+import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
+
+beforeAll(() => {
+  jest.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => {
+    return Promise.resolve();
+  });
+
+  jest.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
 
 describe("AlbumSingleSongコンポーネントの単体テスト", () => {
   test("受け取ったpropsを反映し、正しくレンダリングすること", () => {
-    render(<AlbumSingleSong id={1} num={1} title="タイトル" preview="example.com" />);
+    render(
+      <AlbumAudioProvider>
+        <AlbumSingleSong
+          id={1}
+          num={1}
+          title="タイトル"
+          preview="example.com"
+        />
+      </AlbumAudioProvider>
+    );
 
     expect(screen.getByText("01: タイトル")).toBeInTheDocument();
-    expect(screen.queryByText("プレビューが読み込めません")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("プレビューが読み込めません")
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("button")).toBeInTheDocument();
     expect(screen.getByRole("link")).toHaveAttribute("href", "/music/1");
   });
 
   test("previewがなかった場合に、その旨が表示されること", () => {
-    render(<AlbumSingleSong id={1} num={1} title="タイトル" preview="" />);
+    render(
+      <AlbumAudioProvider>
+        <AlbumSingleSong id={1} num={1} title="タイトル" preview="" />
+      </AlbumAudioProvider>
+    );
     expect(screen.getByText("プレビューが読み込めません")).toBeInTheDocument();
   });
 
   test("numの値が9より大きい場合、先頭に0が付かないこと", () => {
-    render(<AlbumSingleSong id={1} num={15} title="タイトル" preview="example.com" />);
+    render(
+      <AlbumAudioProvider>
+        <AlbumSingleSong
+          id={1}
+          num={15}
+          title="タイトル"
+          preview="example.com"
+        />
+      </AlbumAudioProvider>
+    );
     expect(screen.getByText("15: タイトル")).toBeInTheDocument();
+  });
+
+  test("再生ボタンをクリックすると、playメソッドが呼び出されること", () => {
+    render(
+      <AlbumAudioProvider>
+        <AlbumSingleSong
+          id={1}
+          num={15}
+          title="タイトル"
+          preview="example.com"
+        />
+      </AlbumAudioProvider>
+    );
+
+    const playButton = screen.getByLabelText("playButton");
+    fireEvent.click(playButton);
+
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+  });
+
+  test("停止ボタンをクリックすると、stopメソッドが呼び出されること", () => {
+    render(
+      <AlbumAudioProvider>
+        <AlbumSingleSong
+          id={1}
+          num={15}
+          title="タイトル"
+          preview="example.com"
+        />
+      </AlbumAudioProvider>
+    );
+
+    const stopButton = screen.getByLabelText("stopButton");
+    fireEvent.click(stopButton);
+
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
   });
 });

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useAlbumAudio } from "@/context/AlbumAudioContext";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import Link from "next/link";
 import AlbumSingleSongAudio from "../AlbumSingleSongAudio/AlbumSingleSongAudio";
 import styles from "./AlbumSingleSong.module.css";
-import { useAlbumAudio } from "@/context/AlbumAudioContext";
 
 type AlbumSingleSongProps = {
   id: number;

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import Link from "next/link";
 import AlbumSingleSongAudio from "../AlbumSingleSongAudio/AlbumSingleSongAudio";
 import styles from "./AlbumSingleSong.module.css";
+import { useAlbumAudio } from "@/context/AlbumAudioContext";
 
 type AlbumSingleSongProps = {
   id: number;
@@ -11,11 +14,33 @@ type AlbumSingleSongProps = {
 };
 
 const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
+  // コンテキストからstateを呼び出す
+  const { currentlyPlayingId, setCurrentlyPlayingId } = useAlbumAudio();
+
+  // この楽曲が再生中がどうか返す
+  const isPlaying = currentlyPlayingId === id;
+
+  // 再生中の楽曲のidをstateに格納
+  const handlePlay = () => {
+    setCurrentlyPlayingId(id);
+  };
+
+  // 止めたらstateから削除
+  const handlePause = () => {
+    setCurrentlyPlayingId(null);
+  };
+
+  // 楽曲をナンバリングするための記述
   const displayNum = num.toString().padStart(2, "0");
 
   return (
     <div className={styles.albumSingleContent}>
-      <AlbumSingleSongAudio preview={preview} />
+      <AlbumSingleSongAudio
+        preview={preview}
+        handlePlay={handlePlay}
+        handlePause={handlePause}
+        isPlaying={isPlaying}
+      />
       <div className={styles.albumSingleInfo}>
         <p>
           <Link href={`/music/${id}`}>

--- a/src/components/music/AlbumSingleSongAudio/AlbumSingleSongAudio.tsx
+++ b/src/components/music/AlbumSingleSongAudio/AlbumSingleSongAudio.tsx
@@ -2,54 +2,70 @@
 
 import PlayCircleIcon from "@mui/icons-material/PlayCircle";
 import StopCircleIcon from "@mui/icons-material/StopCircle";
-import { useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
-const AlbumSingleSongAudio = ({ preview }: { preview: string }) => {
-  // 再生中かどうかstateで管理
-  const [isPlaying, setIsPlaying] = useState(false);
+type AlbumSingleSongAudioProps = {
+  preview: string;
+  handlePlay: () => void;
+  handlePause: () => void;
+  isPlaying: boolean;
+};
 
-  // 再レンダリングさせたくないので、useRefでaudio要素を参照
+const AlbumSingleSongAudio = ({
+  preview,
+  handlePlay,
+  handlePause,
+  isPlaying,
+}: AlbumSingleSongAudioProps) => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
-  // 曲を再生
-  const handlePlay = () => {
-    if (audioRef.current) {
+  // 再生状態に応じてオーディオを再生、停止
+  useEffect(() => {
+    // オーディオが存在しているか
+    if (!audioRef.current) {
+      return;
+    }
+    // 現在の楽曲が再生中ならtrue
+    if (isPlaying) {
+      // オーディオ再生
       audioRef.current.play();
-      setIsPlaying(true);
-    }
-  };
-
-  // 曲を一時停止
-  const handlePause = () => {
-    if (audioRef.current) {
+    } else {
+      // オーディオを停止し再生位置リセット
       audioRef.current.pause();
-      setIsPlaying(false);
+      audioRef.current.currentTime = 0;
     }
+  }, [isPlaying]);
+
+  // 停止時にコンテキストの値をリセット
+  const handleEnded = () => {
+    handlePause();
   };
 
   return (
     <>
-      <audio src={preview} ref={audioRef} />
+      <audio src={preview} ref={audioRef} onEnded={handleEnded} />
       <div>
         {preview ? (
           <>
             <PlayCircleIcon
-              onClick={handlePlay}
+              onClick={() => handlePlay()}
               sx={{
                 fontSize: 32,
                 color: !isPlaying ? "#77ffcc" : "#9a9a9a",
                 cursor: "pointer",
               }}
               style={{ pointerEvents: isPlaying ? "none" : "auto" }}
+              aria-label="playButton"
             />
             <StopCircleIcon
-              onClick={handlePause}
+              onClick={() => handlePause()}
               sx={{
                 fontSize: 32,
                 color: isPlaying ? "#77ffcc" : "#9a9a9a",
                 cursor: "pointer",
               }}
               style={{ pointerEvents: isPlaying ? "auto" : "none" }}
+              aria-label="stopButton"
             />
           </>
         ) : (

--- a/src/components/music/AlbumSingles/AlbumSingles.test.tsx
+++ b/src/components/music/AlbumSingles/AlbumSingles.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import AlbumSingles from "./AlbumSingles";
 
+beforeAll(() => {
+  jest.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => {
+    return Promise.resolve();
+  });
+
+  jest.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+});
+
 const AlbumSingleProps = [
   {
     id: 1,

--- a/src/components/music/AlbumSingles/AlbumSingles.tsx
+++ b/src/components/music/AlbumSingles/AlbumSingles.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
 import type { AlbumSingle } from "@/types/deezer";
 import AlbumSingleSong from "../AlbumSingleSong/AlbumSingleSong";
 import styles from "./AlbumSingles.module.css";
-import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
 
 type AlbumSong = {
   id: number;

--- a/src/components/music/AlbumSingles/AlbumSingles.tsx
+++ b/src/components/music/AlbumSingles/AlbumSingles.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import type { AlbumSingle } from "@/types/deezer";
 import AlbumSingleSong from "../AlbumSingleSong/AlbumSingleSong";
 import styles from "./AlbumSingles.module.css";
+import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
 
 type AlbumSong = {
   id: number;
@@ -10,20 +13,23 @@ type AlbumSong = {
 
 const AlbumSingles = ({ singles }: { singles: AlbumSingle[] }) => {
   return (
-    <div className={styles.albumSinglesContent}>
-      {singles.map((song: AlbumSong, index: number) => {
-        return (
-          <div key={song.id} className={styles.albumSingleSong}>
-            <AlbumSingleSong
-              id={song.id}
-              title={song.title}
-              preview={song.preview}
-              num={index + 1}
-            />
-          </div>
-        );
-      })}
-    </div>
+    // Providerでラップすると、子孫コンポーネントがコンテキストにアクセスできるようになる
+    <AlbumAudioProvider>
+      <div className={styles.albumSinglesContent}>
+        {singles.map((song: AlbumSong, index: number) => {
+          return (
+            <div key={song.id} className={styles.albumSingleSong}>
+              <AlbumSingleSong
+                id={song.id}
+                title={song.title}
+                preview={song.preview}
+                num={index + 1}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </AlbumAudioProvider>
   );
 };
 

--- a/src/context/AlbumAudioContext.tsx
+++ b/src/context/AlbumAudioContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useState, useContext, ReactNode } from "react";
+
+// コンテキストのデータの型
+type AudioContextType = {
+  currentlyPlayingId: number | null;
+  setCurrentlyPlayingId: (id: number | null) => void;
+};
+
+// コンテキストオブジェクト nullはデフォルト値
+const AlbumAudioContext = createContext<AudioContextType | null>(null);
+
+// このProviderで囲んだコンポーネントの子孫コンポーネントはここのデータにアクセスできる
+export const AlbumAudioProvider = ({ children }: { children: ReactNode }) => {
+  // 再生中のidをuseStateで管理
+  const [currentlyPlayingId, setCurrentlyPlayingId] = useState<number | null>(
+    null
+  );
+  // Providerのvalueプロパティに共有したい値を設定する
+  // childrenをProviderでラップするために、以下のような記述が必要
+  return (
+    <AlbumAudioContext.Provider
+      value={{ currentlyPlayingId, setCurrentlyPlayingId }}
+    >
+      {children}
+    </AlbumAudioContext.Provider>
+  );
+};
+
+// カスタムフックにする
+// nullの条件分をつけて、Providerの外でカスタムフックを使用したらエラーが出るようにする。
+// これがないと、コンポーネントで型エラーが出てしまう。
+export const useAlbumAudio = () => {
+  const context = useContext(AlbumAudioContext);
+  if (context === null) {
+    throw new Error(
+      "useAlbumAudioはAlbumAudioプロバイダーの中で使用する必要があります"
+    );
+  }
+  return context;
+};

--- a/src/context/AlbumAudioContext.tsx
+++ b/src/context/AlbumAudioContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, ReactNode } from "react";
+import React, { createContext, useState, useContext, type ReactNode } from "react";
 
 // コンテキストのデータの型
 type AudioContextType = {
@@ -12,15 +12,11 @@ const AlbumAudioContext = createContext<AudioContextType | null>(null);
 // このProviderで囲んだコンポーネントの子孫コンポーネントはここのデータにアクセスできる
 export const AlbumAudioProvider = ({ children }: { children: ReactNode }) => {
   // 再生中のidをuseStateで管理
-  const [currentlyPlayingId, setCurrentlyPlayingId] = useState<number | null>(
-    null
-  );
+  const [currentlyPlayingId, setCurrentlyPlayingId] = useState<number | null>(null);
   // Providerのvalueプロパティに共有したい値を設定する
   // childrenをProviderでラップするために、以下のような記述が必要
   return (
-    <AlbumAudioContext.Provider
-      value={{ currentlyPlayingId, setCurrentlyPlayingId }}
-    >
+    <AlbumAudioContext.Provider value={{ currentlyPlayingId, setCurrentlyPlayingId }}>
       {children}
     </AlbumAudioContext.Provider>
   );
@@ -32,9 +28,7 @@ export const AlbumAudioProvider = ({ children }: { children: ReactNode }) => {
 export const useAlbumAudio = () => {
   const context = useContext(AlbumAudioContext);
   if (context === null) {
-    throw new Error(
-      "useAlbumAudioはAlbumAudioプロバイダーの中で使用する必要があります"
-    );
+    throw new Error("useAlbumAudioはAlbumAudioプロバイダーの中で使用する必要があります");
   }
   return context;
 };


### PR DESCRIPTION
## 概要 :bulb:
- アルバム詳細ページ内にて、楽曲が複数再生できてしまう問題を解消。

https://github.com/user-attachments/assets/6a92e1bc-a11f-4815-8b36-d5e7b786c768


## 観点 :eye:
- useContextを用いて不具合を対応
- コンポーネントの単体テストにmockを追加

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:
- AlbumSingleSong、AlbuSinglesコンポーネントの単体テストにmock追加

## 関連する Issue :memo:

## 補足情報 :notes:

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)

ご確認よろしくお願いいたします。
