### PR TITLE
トップページのスライダーを特集のサムネイルに変更

### DIFF
--- a/src/app/(top)/page.tsx
+++ b/src/app/(top)/page.tsx
@@ -1,3 +1,4 @@
+import { getSpecialImage } from "@/components/special/TopPageLink/TopPageLink";
 import BreadList from "@/components/top/BreadList/BreadList";
 import ContentTitle from "@/components/top/ContentTitle/ContentTitle";
 import FreeSearch from "@/components/top/FreeSearch/FreeSearch";
@@ -13,14 +14,15 @@ const TopPage = async () => {
   const newSongs = await getNewSongs(4);
   // シングルランキング楽曲を取得
   const singleSongs = await getRankSingleSongs(4);
-
+  // sliderの特集情報を取得
+  const getPicksInfo = await getSpecialImage();
   return (
     <div>
       <BreadList bread={[{ link: "/", title: "TOP" }]} />
       <div>
         <div className={styles.specialContent}>
           <ContentTitle title="特集" />
-          <Slider />
+          <Slider getPicksInfo={getPicksInfo} />
         </div>
 
         <div className={styles.freeSearchContent}>

--- a/src/app/special/[id]/page.tsx
+++ b/src/app/special/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Special } from "@/components/special/DetailPage/Special/Special";
+import { getSpecialImage } from "@/components/special/TopPageLink/TopPageLink";
 import BreadList from "@/components/top/BreadList/BreadList";
 import type { ReadonlyURLSearchParams } from "next/navigation";
-import { getSpecialImage } from "@/components/special/TopPageLink/TopPageLink";
 
 type SongPageProps = {
   params: { id: number };

--- a/src/app/special/[id]/page.tsx
+++ b/src/app/special/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { Special } from "@/components/special/DetailPage/Special/Special";
 import BreadList from "@/components/top/BreadList/BreadList";
 import type { ReadonlyURLSearchParams } from "next/navigation";
+import { getSpecialImage } from "@/components/special/TopPageLink/TopPageLink";
 
 type SongPageProps = {
   params: { id: number };
@@ -9,13 +10,16 @@ type SongPageProps = {
 
 const Page = async ({ params }: SongPageProps) => {
   const { id } = params;
-
+  const specialOverViews = await getSpecialImage();
+  const specialOverView = specialOverViews[id - 1];
   return (
     <>
       <BreadList
         bread={[
           { link: "/", title: "TOP" },
           { link: "/special", title: "特集" },
+
+          { link: `/special/${id}`, title: `${specialOverView.title}` },
         ]}
       />
       <Special id={id} />

--- a/src/components/special/DetailPage/Special/Special.tsx
+++ b/src/components/special/DetailPage/Special/Special.tsx
@@ -6,7 +6,7 @@ import { SpecialPlaylist } from "../SpecialPlaylist/SpecialPlaylist";
 import { SpecialTitles } from "../SpecialTitles/SpecialTitles";
 import styles from "./Special.module.css";
 
-const getSpecialImage = async () => {
+export const getSpecialImage = async () => {
   const response = await fetch("http://localhost:3000/api/getSpecialImage", {
     cache: "no-store",
   });
@@ -17,7 +17,7 @@ const getSpecialImage = async () => {
   return specialOverViews;
 };
 
-const getSpecialSongs = async (id: number) => {
+export const getSpecialSongs = async (id: number) => {
   const response = await fetch(`http://localhost:3000/api/getSpecialSongs?id=${id}`, {
     cache: "no-store",
   });
@@ -28,7 +28,7 @@ const getSpecialSongs = async (id: number) => {
   return specialSongs;
 };
 
-const getSpecialSongInfo = async (id: number) => {
+export const getSpecialSongInfo = async (id: number) => {
   const playlistSongs = await getSpecialSongs(id);
   const response = await fetch("http://localhost:3000/api/getSpecialSongInfo", {
     method: "POST",

--- a/src/components/top/Slider/Slider.tsx
+++ b/src/components/top/Slider/Slider.tsx
@@ -1,18 +1,18 @@
 "use client";
 
 import Image from "next/image";
-import "swiper/css";
 import { Autoplay, Keyboard, Navigation, Pagination } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/pagination";
-import { SLIDER_IMAGES } from "@/constants/constant";
+import type { SpecialOverView } from "@/types/deezer";
+import Link from "next/link";
 
-const Slider = () => {
+const Slider = ({ getPicksInfo }: { getPicksInfo: SpecialOverView[] }) => {
   return (
     <div>
       <Swiper
-        slidesPerView={2}
+        slidesPerView={1.5}
         spaceBetween={15}
         centeredSlides={true}
         keyboard={{
@@ -30,10 +30,18 @@ const Slider = () => {
         modules={[Autoplay, Keyboard, Pagination, Navigation]}
         className="mySwiper"
       >
-        {SLIDER_IMAGES.map((image) => {
+        {getPicksInfo.map((getPickInfo) => {
           return (
-            <SwiperSlide key={image}>
-              <Image src={image} alt="スライダー画像" width={150} height={100} priority />
+            <SwiperSlide key={getPickInfo.id}>
+              <Link href={`/special/${getPickInfo.id}`}>
+                <Image
+                  src={`/images/${getPickInfo.image}`}
+                  alt="スライダー画像"
+                  width={300}
+                  height={150}
+                  priority
+                />
+              </Link>
             </SwiperSlide>
           );
         })}

--- a/src/components/top/Slider/Slider.tsx
+++ b/src/components/top/Slider/Slider.tsx
@@ -36,7 +36,7 @@ const Slider = ({ getPicksInfo }: { getPicksInfo: SpecialOverView[] }) => {
               <Link href={`/special/${getPickInfo.id}`}>
                 <Image
                   src={`/images/${getPickInfo.image}`}
-                  alt="スライダー画像"
+                  alt={`${getPickInfo.title}サムネイル`}
                   width={300}
                   height={150}
                   priority


### PR DESCRIPTION
## 概要 :bulb:

- トップページのスライダーの画像を特集のサムネイルに変更し、リンクを付けました。
- 各特集のパンくずリストに、特集タイトルを適用しました。

![image](https://github.com/user-attachments/assets/cc71beba-e737-485b-bbe8-b04f923a65c5)
---

![image](https://github.com/user-attachments/assets/f3149b98-b8b8-4074-8289-f0a89e26538c)

## 観点 :eye:

- サムネイルのサイズ的に、スライダーのpreview(1度に何枚分入るか)を2→1.5と変更しましたが、見た目に問題ないでしょうか？
- src/app/(top)/page.tsx でDBのPickテーブルの情報を取得する関数を呼び出し、スライダーコンポーネントに取得したデータを渡すようにしています。

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
