### PR TITLE
ヘッダー、各種詳細ページのスタイルを変更

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,14 +2,15 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
-}
-
-body {
   color: #525252;
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+main {
+  margin-top: 100px;
 }
 
 * {

--- a/src/components/frame/header/Header.module.css
+++ b/src/components/frame/header/Header.module.css
@@ -65,7 +65,10 @@
   margin-right: 1.1rem;
 }
 
-.searchCancelText {
-  margin: auto;
+.searchCancelButton {
+  background-color: white;
+  border: none;
   cursor: pointer;
+  height: fit-content;
+  margin: auto;
 }

--- a/src/components/frame/header/Header.module.css
+++ b/src/components/frame/header/Header.module.css
@@ -1,11 +1,14 @@
 .container {
   width: 100%;
-  position: relative;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 9999;
 }
 
 .headerTop {
   display: flex;
-  height: 80px;
+  height: 60px;
   background-color: white;
   justify-content: space-between;
 }
@@ -14,12 +17,12 @@
   display: flex;
   margin: auto;
   align-items: center;
-  height: 80px;
+  height: 60px;
 }
 
 .searchIcon {
   display: flex;
-  min-width: 80px;
+  min-width: 60px;
 }
 
 .searchIconMark {
@@ -32,6 +35,7 @@
 
 .freeSearch {
   display: flex;
+  flex: 1;
   justify-content: space-between;
   color: #525252;
 }
@@ -40,7 +44,6 @@
   flex: 1;
   padding: 0.3rem 0.6rem;
   margin: 1.2rem 0 1.2rem 1.5rem;
-  width: 18rem;
   border-radius: 20px;
   border: 1px solid #c3c3c3b7;
   box-shadow: none;
@@ -62,7 +65,7 @@
 .searchCancel {
   display: flex;
   font-size: 0.7rem;
-  margin-right: 1.1rem;
+  margin: 0 0.5rem;
 }
 
 .searchCancelButton {

--- a/src/components/frame/header/Header.test.tsx
+++ b/src/components/frame/header/Header.test.tsx
@@ -77,7 +77,7 @@ describe("ヘッダーコンポーネントの単体テスト", () => {
 
     const input = screen.getByPlaceholderText("アーティスト・アルバム・楽曲で検索");
     expect(input).toBeInTheDocument();
-    expect(screen.getByText("キャンセル")).toBeInTheDocument();
+    expect(screen.getByTestId("cancel-button")).toBeInTheDocument();
   });
 
   test("未入力状態で検索をかけるとplaceholderに「検索ワードを入力してください。」と表示される", async () => {
@@ -100,7 +100,7 @@ describe("ヘッダーコンポーネントの単体テスト", () => {
     const searchIcon = screen.getByTestId("search-icon");
     fireEvent.click(searchIcon);
 
-    const searchCancel = screen.getByText("キャンセル");
+    const searchCancel = screen.getByTestId("cancel-button");
     fireEvent.click(searchCancel);
 
     expect(screen.getByTestId("hamburger-menu")).toBeInTheDocument();

--- a/src/components/frame/header/Header.tsx
+++ b/src/components/frame/header/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useFreeWordSearch } from "@/hooks/top/useFreeWordSearch";
+import CancelIcon from "@mui/icons-material/Cancel";
 import SearchIcon from "@mui/icons-material/Search";
 import Image from "next/image";
 import Link from "next/link";

--- a/src/components/frame/header/Header.tsx
+++ b/src/components/frame/header/Header.tsx
@@ -39,13 +39,15 @@ const Header = () => {
                 </button>
               </form>
               <div className={styles.searchCancel}>
-                <p
-                  className={styles.searchCancelText}
+                <button
+                  type="button"
+                  className={styles.searchCancelButton}
                   onClick={handleClickSearch}
                   onKeyDown={handleClickSearch}
+                  data-testid="cancel-button"
                 >
-                  キャンセル
-                </p>
+                  <CancelIcon />
+                </button>
               </div>
             </div>
           ) : (

--- a/src/components/frame/header/PageHeadingList.module.css
+++ b/src/components/frame/header/PageHeadingList.module.css
@@ -1,9 +1,10 @@
 .headerBottom {
-  height: 50px;
+  height: 40px;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   border-top: 1px solid gray;
   border-bottom: 1px solid gray;
+  background-color: white;
 }
 
 .thePageHeading,

--- a/src/components/music/AlbumInfo/AlbumInfo.module.css
+++ b/src/components/music/AlbumInfo/AlbumInfo.module.css
@@ -43,6 +43,7 @@
   padding: 0.2rem 0.3rem;
   max-width: 185px;
   cursor: pointer;
+  transition: background-color 0.3s ease-in, color 0.3s ease-in, border-color 0.3s ease-in;
 }
 
 .albumInfoAddFavorite {
@@ -57,6 +58,7 @@
   padding: 0.2rem 0.3rem;
   max-width: 185px;
   cursor: pointer;
+  transition: background-color 0.3s ease-in, color 0.3s ease-in, border-color 0.3s ease-in;
 }
 
 .albumInfoAddFavorite:hover {

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
@@ -1,6 +1,11 @@
 .albumSingleContent {
   display: flex;
   align-items: center;
+  padding: 0.2rem 0;
+}
+
+.albumSingleContent:hover {
+  background-color: #dcdcdc79;
 }
 
 .albumSingleInfo {

--- a/src/components/music/AlbumSingles/AlbumSingles.module.css
+++ b/src/components/music/AlbumSingles/AlbumSingles.module.css
@@ -4,5 +4,4 @@
 
 .albumSingleSong {
   border-bottom: 1px solid rgb(203, 203, 203);
-  padding-bottom: 0.2rem;
 }

--- a/src/components/music/ArtistInfo/ArtistInfo.module.css
+++ b/src/components/music/ArtistInfo/ArtistInfo.module.css
@@ -24,6 +24,7 @@
   cursor: pointer;
   padding: 0.2rem 0.6rem;
   border: 2px solid white;
+  transition: background-color 0.3s ease-in, color 0.3s ease-in, border 0.3s ease-in;
 }
 
 .artistInfoContent > div:hover {

--- a/src/components/music/ImageTitleLink/ImageTitleLink.module.css
+++ b/src/components/music/ImageTitleLink/ImageTitleLink.module.css
@@ -15,3 +15,7 @@
 .imageTitleContent > p {
   text-align: center;
 }
+
+.imageTitleContent:hover {
+  background-color: #dcdcdc79;
+}

--- a/src/components/music/SongInfoContent/SongInfoContent.module.css
+++ b/src/components/music/SongInfoContent/SongInfoContent.module.css
@@ -43,6 +43,7 @@
   padding: 0.2rem 0.3rem;
   max-width: 185px;
   cursor: pointer;
+  transition: background-color 0.3s ease-in, color 0.3s ease-in, border-color 0.3s ease-in;
 }
 
 .songInfoAddFavorite {
@@ -57,6 +58,7 @@
   padding: 0.2rem 0.3rem;
   max-width: 185px;
   cursor: pointer;
+  transition: background-color 0.3s ease-in, color 0.3s ease-in, border-color 0.3s ease-in;
 }
 
 .songInfoAddFavorite:hover {

--- a/src/components/mypage/SongListItem/SongListItem.module.css
+++ b/src/components/mypage/SongListItem/SongListItem.module.css
@@ -6,6 +6,10 @@
   border-top: solid 1px #ccc;
 }
 
+.songInfo:hover {
+  background-color: #dcdcdc79;
+}
+
 .songInfo > img {
   border-radius: 5px;
   box-shadow: 0px 0px 15px -5px #777777;

--- a/src/components/mypage/SongListItem/SongListItem.tsx
+++ b/src/components/mypage/SongListItem/SongListItem.tsx
@@ -6,21 +6,19 @@ import styles from "./SongListItem.module.css";
 
 const SongListItem = ({ song, url }: { song: DeezerSong; url: string }) => {
   return (
-    <Link href={`/${url}/${song.id}`}>
-      <div className={styles.songInfo}>
-        <Image
-          src={song.cover_xl || song.album.cover_xl || ""}
-          alt={`${song.title}のジャケット画像`}
-          width={75}
-          height={75}
-          priority
-        />
-        <div>
-          <p className={styles.songTitle}>{song.title}</p>
-          <p className={styles.artistName}>{song.artist.name}</p>
-        </div>
-        <ArrowForwardIosIcon fontSize="small" color="disabled" />
+    <Link href={`/${url}/${song.id}`} className={styles.songInfo}>
+      <Image
+        src={song.cover_xl || song.album.cover_xl || ""}
+        alt={`${song.title}のジャケット画像`}
+        width={75}
+        height={75}
+        priority
+      />
+      <div>
+        <p className={styles.songTitle}>{song.title}</p>
+        <p className={styles.artistName}>{song.artist.name}</p>
       </div>
+      <ArrowForwardIosIcon fontSize="small" color="disabled" />
     </Link>
   );
 };


### PR DESCRIPTION
## 概要 :bulb:
- ヘッダー上部固定表示
- ヘッダーあいまい検索キャンセルボタンにMUIのアイコンを使用
- 楽曲詳細、アルバム詳細、アーティスト詳細のスタイルを変更(主にCSS)

https://github.com/user-attachments/assets/07963282-98ea-49ef-b63b-b332fde506ac


## 観点 :eye:
#### ヘッダーを上部固定
- スクロールしても上部に常に表示されるようにしました。
- ヘッダー全体の高さを低くしました。
- あいまい検索のキャンセルボタンをMUIのアイコンに変更

#### 各種詳細ページ　スタイル変更
- 主にマウスホバー時に背景色が灰色になるような変更をしています。
- お気に入り追加ボタンなどは急に色が変わるのではなく、グラデーションで変わるようにしました。

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

## 関連する Issue :memo:

## 補足情報 :notes:

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3)
