### PR TITLE
視聴履歴表示コンポーネント作成 UIのみ

### DIFF
--- a/src/app/album/[id]/page.module.css
+++ b/src/app/album/[id]/page.module.css
@@ -7,7 +7,8 @@
 .albumDetailContent,
 .albumSongsContent,
 .artistInfoLinkContent,
-.artistFavoriteSongsContent {
+.artistFavoriteSongsContent,
+.historySongsContent {
   padding: 2rem 0;
   border-bottom: 2px solid #c7c7c7;
 }

--- a/src/app/album/[id]/page.tsx
+++ b/src/app/album/[id]/page.tsx
@@ -64,7 +64,7 @@ const AlbumPage = async ({ params }: AlbumPageProps) => {
         </div>
 
         <div className={styles.historySongsContent}>
-          <MusicContentTitle title="視聴履歴" />
+          <MusicContentTitle title="試聴履歴" />
           <PlayHistory />
         </div>
       </div>

--- a/src/app/album/[id]/page.tsx
+++ b/src/app/album/[id]/page.tsx
@@ -2,6 +2,7 @@ import AlbumInfo from "@/components/music/AlbumInfo/AlbumInfo";
 import AlbumSingles from "@/components/music/AlbumSingles/AlbumSingles";
 import ImageTitleLink from "@/components/music/ImageTitleLink/ImageTitleLink";
 import MusicContentTitle from "@/components/music/MusicContentTitle/MusicContentTitle";
+import PlayHistory from "@/components/music/PlayHistory/PlayHistory";
 import SongList from "@/components/mypage/SongList/SongList";
 import BreadList from "@/components/top/BreadList/BreadList";
 import { getAlbum, getArtistSongs } from "@/utils/apiFunc";
@@ -60,6 +61,11 @@ const AlbumPage = async ({ params }: AlbumPageProps) => {
             url="music"
             errorMessage="人気楽曲を取得できませんでした"
           />
+        </div>
+
+        <div className={styles.historySongsContent}>
+          <MusicContentTitle title="視聴履歴" />
+          <PlayHistory />
         </div>
       </div>
     </>

--- a/src/app/artist/[id]/page.module.css
+++ b/src/app/artist/[id]/page.module.css
@@ -11,7 +11,8 @@
 
 .artistInfoContent,
 .singleContent,
-.albumContent {
+.albumContent,
+.historySongsContent {
   margin-top: 1.5rem;
   border-bottom: 1px solid lightgray;
   padding-bottom: 1.5rem;

--- a/src/app/artist/[id]/page.tsx
+++ b/src/app/artist/[id]/page.tsx
@@ -1,5 +1,6 @@
 import ArtistInfo from "@/components/music/ArtistInfo/ArtistInfo";
 import MusicContentTitle from "@/components/music/MusicContentTitle/MusicContentTitle";
+import PlayHistory from "@/components/music/PlayHistory/PlayHistory";
 import SongList from "@/components/mypage/SongList/SongList";
 import BreadList from "@/components/top/BreadList/BreadList";
 import { getArtist, getArtistAlbum, getArtistSongs } from "@/utils/apiFunc";
@@ -54,6 +55,11 @@ const ArtistPage = async ({ params }: ArtistPageProps) => {
             url="album"
             errorMessage="アルバムを取得できませんでした"
           />
+        </div>
+
+        <div className={styles.historySongsContent}>
+          <MusicContentTitle title="視聴履歴" />
+          <PlayHistory />
         </div>
       </div>
     </>

--- a/src/app/artist/[id]/page.tsx
+++ b/src/app/artist/[id]/page.tsx
@@ -58,7 +58,7 @@ const ArtistPage = async ({ params }: ArtistPageProps) => {
         </div>
 
         <div className={styles.historySongsContent}>
-          <MusicContentTitle title="視聴履歴" />
+          <MusicContentTitle title="試聴履歴" />
           <PlayHistory />
         </div>
       </div>

--- a/src/app/music/[id]/page.module.css
+++ b/src/app/music/[id]/page.module.css
@@ -6,7 +6,8 @@
 
 .artistInfoLinkContent,
 .artistFavoriteSongsContent,
-.songDetailContent {
+.songDetailContent,
+.historySongsContent {
   padding-top: 2rem;
   padding-bottom: 2rem;
   border-bottom: 2px solid #c7c7c7;

--- a/src/app/music/[id]/page.tsx
+++ b/src/app/music/[id]/page.tsx
@@ -59,7 +59,7 @@ const SongPage = async ({ params }: SongPageProps) => {
         </div>
 
         <div className={styles.historySongsContent}>
-          <MusicContentTitle title="視聴履歴" />
+          <MusicContentTitle title="試聴履歴" />
           <PlayHistory />
         </div>
       </div>

--- a/src/app/music/[id]/page.tsx
+++ b/src/app/music/[id]/page.tsx
@@ -1,5 +1,6 @@
 import ImageTitleLink from "@/components/music/ImageTitleLink/ImageTitleLink";
 import MusicContentTitle from "@/components/music/MusicContentTitle/MusicContentTitle";
+import PlayHistory from "@/components/music/PlayHistory/PlayHistory";
 import SongInfoContent from "@/components/music/SongInfoContent/SongInfoContent";
 import SongList from "@/components/mypage/SongList/SongList";
 import BreadList from "@/components/top/BreadList/BreadList";
@@ -55,6 +56,11 @@ const SongPage = async ({ params }: SongPageProps) => {
             url="music"
             errorMessage="人気楽曲を取得できませんでした"
           />
+        </div>
+
+        <div className={styles.historySongsContent}>
+          <MusicContentTitle title="視聴履歴" />
+          <PlayHistory />
         </div>
       </div>
     </>

--- a/src/components/music/PlayHistory/PlayHistory.module.css
+++ b/src/components/music/PlayHistory/PlayHistory.module.css
@@ -1,0 +1,50 @@
+.playHistoryGroup {
+  display: grid;
+  grid-template-columns: repeat(3, 30%);
+  grid-template-rows: repeat(2, 1fr);
+  place-items: stretch;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  width: 100%;
+}
+
+.playHistorySong {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  border-radius: 10px;
+  padding: 0.2rem;
+}
+
+.playHistorySong:hover {
+  background-color: #c9c9c92d;
+}
+
+.playHistorySong > img {
+  width: 100%;
+  height: auto;
+  border-radius: 10px;
+  box-shadow: 0px 0px 10px -5px #777777;
+  transition: opacity 0.3s ease-in;
+}
+
+.playHistorySong > img:hover {
+  opacity: 0.8;
+}
+
+.playHistorySong > p {
+  font-size: 0.8rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.playHistorySong > p:first-of-type {
+  font-weight: bold;
+}
+
+.nothingHistory {
+  font-weight: bold;
+  text-wrap: nowrap;
+}

--- a/src/components/music/PlayHistory/PlayHistory.test.tsx
+++ b/src/components/music/PlayHistory/PlayHistory.test.tsx
@@ -1,0 +1,20 @@
+import { HISTORY } from "@/constants/constant";
+import { render, screen } from "@testing-library/react";
+import PlayHistory from "./PlayHistory";
+
+describe("PlayHistoryコンポーネントの単体テスト", () => {
+  beforeEach(() => {
+    render(<PlayHistory />);
+  });
+  test("受け取ったpropsを反映し、レンダリングされること", () => {
+    HISTORY.map((song: { id: number; image: string; title: string; artist: string }) => {
+      expect(screen.getByText(song.title)).toBeInTheDocument();
+    });
+  });
+
+  test("指定された件数履歴が表示できていること", () => {
+    expect(screen.getAllByRole("link")).toHaveLength(6);
+  });
+
+  // FIXME: 視聴履歴がなかった場合のテストを処理を追加したら記載する
+});

--- a/src/components/music/PlayHistory/PlayHistory.tsx
+++ b/src/components/music/PlayHistory/PlayHistory.tsx
@@ -1,0 +1,34 @@
+import { HISTORY } from "@/constants/constant";
+import Image from "next/image";
+import Link from "next/link";
+import styles from "./PlayHistory.module.css";
+
+const PlayHistory = () => {
+  // FIXME: 仮の視聴履歴を使用しています。
+  return (
+    <div className={styles.playHistoryGroup}>
+      {HISTORY.length > 0 ? (
+        HISTORY.map(
+          (song: {
+            id: number;
+            image: string;
+            title: string;
+            artist: string;
+          }) => {
+            return (
+              <Link href="/" key={song.id} className={styles.playHistorySong}>
+                <Image src={song.image} alt={`${song.title}の画像`} width={150} height={150} />
+                <p>{song.title}</p>
+                <p>{song.artist}</p>
+              </Link>
+            );
+          },
+        )
+      ) : (
+        <p className={styles.nothingHistory}>視聴履歴がありません</p>
+      )}
+    </div>
+  );
+};
+
+export default PlayHistory;

--- a/src/components/music/PlayHistory/PlayHistory.tsx
+++ b/src/components/music/PlayHistory/PlayHistory.tsx
@@ -25,7 +25,7 @@ const PlayHistory = () => {
           },
         )
       ) : (
-        <p className={styles.nothingHistory}>視聴履歴がありません</p>
+        <p className={styles.nothingHistory}>試聴履歴がありません</p>
       )}
     </div>
   );

--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -1,11 +1,3 @@
-// スライダーに表示させる画像パス、今後リンクにする必要があります(topページ)
-export const SLIDER_IMAGES = [
-  "/images/sliderImage1.png",
-  "/images/sliderImage2.png",
-  "/images/sliderImage3.png",
-  "/images/sliderImage4.png",
-];
-
 // 表示させるアーティストのジャンル
 export const GENRE_ARTISTS = [
   { id: 0, name: "すべて" },
@@ -21,3 +13,43 @@ export const GENRE_ARTISTS = [
 
 // cookieの有効期限(1日)
 export const COOKIE_MAX_AGE = 60 * 60 * 24;
+
+// FIXME: 視聴履歴表示に伴う仮の情報。今後deezerから取得したデータに変更する必要があります。
+export const HISTORY = [
+  {
+    id: 1,
+    image: "/images/defaultsong.png",
+    title: "楽曲名1文字列が続きます。文字列が続きます。",
+    artist: "アーティスト名文字列が続きます。文字列が続きます。",
+  },
+  {
+    id: 2,
+    image: "/images/defaultsong.png",
+    title: "楽曲名2文字列が続きます。",
+    artist: "アーティスト名文字列が続きます。",
+  },
+  {
+    id: 3,
+    image: "/images/defaultsong.png",
+    title: "楽曲名3",
+    artist: "アーティスト名",
+  },
+  {
+    id: 4,
+    image: "/images/defaultsong.png",
+    title: "楽曲名4",
+    artist: "アーティスト名",
+  },
+  {
+    id: 5,
+    image: "/images/defaultsong.png",
+    title: "楽曲名5",
+    artist: "アーティスト名",
+  },
+  {
+    id: 6,
+    image: "/images/defaultsong.png",
+    title: "楽曲名6",
+    artist: "アーティスト名",
+  },
+];


### PR DESCRIPTION
## 概要 :bulb:
- 視聴履歴を表示するコンポーネントのUIのみ作成

<img width="300" alt="スクリーンショット 2024-11-13 14 30 16" src="https://github.com/user-attachments/assets/16f6f52a-6f23-422c-a851-9e7083227fb5">

<img width="300" alt="スクリーンショット 2024-11-13 14 30 45" src="https://github.com/user-attachments/assets/92f72f71-d5c0-4b52-bd56-41d876869d3b">


## 観点 :eye:
#### 視聴履歴表示コンポーネント作成(/components/music/PlayHistory)
- １行当たり3件の楽曲を表示しています。
- 文字数が長い時に...表示されるようにしました。
- 楽曲取得処理は未実装なので、定数で代用しています。
- 視聴履歴の型指定も仮置きでpropsの横に記述しています。処理追加後にtypesに記載します。
- アーティスト、楽曲、アルバム詳細ページにて表示しています。
- 視聴履歴がなかった場合、その旨が表示されます。
- 単体テスト実施、処理を実装した後に追記箇所あります。

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [x] 特定の個人・団体名などを使用していないか
- [x] 接続情報など秘密情報が含まれていないか
- [x] ログに個人情報等が含まれていないか
- [x] ドメインは example.com を使用しているか

## テスト :test_tube:
- PlayHistoryコンポーネントの単体テスト作成

## 関連する Issue :memo:
#66 
## 補足情報 :notes:

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
