### PR TITLE
あいまい検索結果の表示の切り替えを実装

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -13,6 +13,7 @@ const Search = ({
   const freeWord = searchParams.q;
   const searchTotal = searchParams.n;
   const kind = searchParams.k;
+  const style = searchParams.s;
   return (
     <div>
       <BreadList
@@ -31,7 +32,7 @@ const Search = ({
         </div>
 
         <div>
-          <SearchKind freeWord={freeWord} searchTotal={searchTotal} kind={kind} />
+          <SearchKind freeWord={freeWord} searchTotal={searchTotal} kind={kind} style={style} />
         </div>
       </div>
     </div>

--- a/src/components/search/SearchAlbumContent/SearchAlbum.module.css
+++ b/src/components/search/SearchAlbumContent/SearchAlbum.module.css
@@ -1,6 +1,30 @@
-.albumInfo {
+.albumInfoGrid {
   display: flex;
   flex-direction: column;
+}
+
+.albumInfoGrid img {
+  border-radius: 10px;
+  box-shadow: 0px 0px 15px -5px #777777;
+  width: 100%;
+  height: 100%;
+}
+
+.albumInfoGrid > p {
+  margin: 0.3rem 0;
+  line-height: 1;
+}
+
+.albumInfo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border-top: solid rgb(116, 116, 116) 0.05rem;
+  border-bottom: solid rgb(116, 116, 116) 0.05rem;
+}
+
+.albumInfo + .albumInfo {
+  border-top: none;
 }
 
 .albumInfo img {
@@ -8,9 +32,11 @@
   box-shadow: 0px 0px 15px -5px #777777;
   width: 100%;
   height: 100%;
+  margin: 0.5rem 0;
 }
 
-.albumInfo > p {
-  margin: 0.3rem 0;
-  line-height: 1;
+.albumInfo p {
+  margin: 0;
+  width: 16rem;
+  text-align: left;
 }

--- a/src/components/search/SearchAlbumContent/SearchAlbum.test.tsx
+++ b/src/components/search/SearchAlbumContent/SearchAlbum.test.tsx
@@ -15,18 +15,18 @@ const url = "album";
 
 describe("SearchAlbumContentの単体テスト", () => {
   test("アルバム名が表示されているか", () => {
-    render(<SearchAlbumContent result={mockResult} url="album" />);
+    render(<SearchAlbumContent result={mockResult} url={url} style="grid" />);
 
     expect(screen.getByText("sampleAlbum")).toBeInTheDocument();
   });
 
   test("アーティスト名が表示されているか", () => {
-    const { getByText } = render(<SearchAlbumContent result={mockResult} url="album" />);
+    const { getByText } = render(<SearchAlbumContent result={mockResult} url={url} style="grid" />);
     expect(getByText("sampleArtist")).toBeInTheDocument();
   });
 
   test("画像が正しく表示されているか", () => {
-    render(<SearchAlbumContent result={mockResult} url="albu" />);
+    render(<SearchAlbumContent result={mockResult} url={url} style="grid" />);
 
     const image = screen.getByRole("img");
     //srcが正しいか
@@ -36,7 +36,7 @@ describe("SearchAlbumContentの単体テスト", () => {
   });
 
   test("リンクが正しいURLかどうか", () => {
-    render(<SearchAlbumContent result={mockResult} url={url} />);
+    render(<SearchAlbumContent result={mockResult} url={url} style="grid" />);
 
     const link = screen.getByRole("link");
 

--- a/src/components/search/SearchAlbumContent/SearchAlbumContent.tsx
+++ b/src/components/search/SearchAlbumContent/SearchAlbumContent.tsx
@@ -7,23 +7,27 @@ import styles from "./SearchAlbum.module.css";
 const SearchAlbumContent = ({
   result,
   url,
+  style,
 }: {
   result: SearchAlbum;
   url: string;
+  style: string;
 }) => {
   return (
-    <Link href={`/${url}/${result.id}`}>
-      <div className={styles.albumInfo}>
+    <div className={style === "grid" ? styles.albumInfoGrid : styles.albumInfo}>
+      <Link href={`/${url}/${result.id}`}>
         <Image
           src={result.cover_xl || "/images/defaultsong.png"}
           alt={`${result.artist.name}の画像`}
           width={180}
           height={180}
         />
+      </Link>
+      <div>
         <p>{result.title}</p>
         <p>{result.artist.name}</p>
       </div>
-    </Link>
+    </div>
   );
 };
 

--- a/src/components/search/SearchAlbumResult/SearchAlbumResult.tsx
+++ b/src/components/search/SearchAlbumResult/SearchAlbumResult.tsx
@@ -8,9 +8,11 @@ import styles from "./SearchAlbumResult.module.css";
 const SearchAlbumResult = async ({
   freeWord,
   url,
+  style,
 }: {
   freeWord: string;
   url: string;
+  style: string;
 }) => {
   //アルバムの検索結果を取得する関数を呼び出し
   const searchAlbum = await getArtistAlbum(freeWord);
@@ -21,9 +23,9 @@ const SearchAlbumResult = async ({
       <div>
         <SearchTotal searchTotal={String(resultAlbum.length)} name="アルバム" />
       </div>
-      <div className={styles.albumGroup}>
+      <div className={style === "grid" ? styles.albumGroup : styles.none}>
         {resultAlbum.map((result: SearchAlbum) => {
-          return <SearchAlbumContent key={result.id} result={result} url={url} />;
+          return <SearchAlbumContent key={result.id} result={result} url={url} style={style} />;
         })}
       </div>
     </>

--- a/src/components/search/SearchArtistResult/SearchArtistResult.tsx
+++ b/src/components/search/SearchArtistResult/SearchArtistResult.tsx
@@ -7,9 +7,11 @@ import styles from "./SearchArtistResult.module.css";
 const SearchArtistResult = async ({
   freeWord,
   url,
+  style,
 }: {
   freeWord: string;
   url: string;
+  style: string;
 }) => {
   const res = await getFreeArtist(freeWord);
   const searchArtist: DeezerArtist[] = res.resultData;
@@ -19,9 +21,11 @@ const SearchArtistResult = async ({
       <div>
         <SearchTotal searchTotal={String(searchArtist.length)} name="アーティスト" />
       </div>
-      <div className={styles.artistGroup}>
+      <div className={style === "grid" ? styles.artistGroup : styles.none}>
         {searchArtist.map((result: DeezerArtist) => {
-          return <SearchArtistResultContent key={result.id} result={result} url={url} />;
+          return (
+            <SearchArtistResultContent key={result.id} result={result} url={url} style={style} />
+          );
         })}
       </div>
     </div>

--- a/src/components/search/SearchArtistResultContent/SearchArtistResultContent.module.css
+++ b/src/components/search/SearchArtistResultContent/SearchArtistResultContent.module.css
@@ -1,6 +1,30 @@
-.artistInfo {
+.artistInfoGrid {
   display: flex;
   flex-direction: column;
+}
+
+.artistInfoGrid img {
+  border-radius: 50%;
+  box-shadow: 0px 0px 15px -5px #777777;
+  width: 100%;
+  height: 100%;
+}
+
+.artistInfoGrid > p {
+  margin: 0.3rem 0;
+  line-height: 1;
+}
+
+.artistInfo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border-top: solid rgb(116, 116, 116) 0.05rem;
+  border-bottom: solid rgb(116, 116, 116) 0.05rem;
+}
+
+.artistInfo + .artistInfo {
+  border-top: none;
 }
 
 .artistInfo img {
@@ -8,9 +32,11 @@
   box-shadow: 0px 0px 15px -5px #777777;
   width: 100%;
   height: 100%;
+  margin: 0.5rem 0;
 }
 
-.artistInfo > p {
-  margin: 0.3rem 0;
-  line-height: 1;
+.artistInfo p {
+  margin: 0;
+  width: 16rem;
+  text-align: left;
 }

--- a/src/components/search/SearchArtistResultContent/SearchArtistResultContent.test.tsx
+++ b/src/components/search/SearchArtistResultContent/SearchArtistResultContent.test.tsx
@@ -10,13 +10,13 @@ const mockResult: DeezerArtist = {
 
 describe("SearchArtistContentの単体テスト", () => {
   test("アーティスト名が正しく表示されているか", () => {
-    render(<SearchArtistResultContent result={mockResult} url="artist" />);
+    render(<SearchArtistResultContent result={mockResult} url="artist" style="grid" />);
 
     expect(screen.getByText("test")).toBeInTheDocument();
   });
 
   test("画像が正しく表示されているか", () => {
-    render(<SearchArtistResultContent result={mockResult} url="artist" />);
+    render(<SearchArtistResultContent result={mockResult} url="artist" style="grid" />);
 
     const image = screen.getByRole("img");
 
@@ -27,7 +27,7 @@ describe("SearchArtistContentの単体テスト", () => {
   });
 
   test("リンクが正しいかどうか", () => {
-    render(<SearchArtistResultContent result={mockResult} url="artist" />);
+    render(<SearchArtistResultContent result={mockResult} url="artist" style="grid" />);
 
     const link = screen.getByRole("link");
 

--- a/src/components/search/SearchArtistResultContent/SearchArtistResultContent.tsx
+++ b/src/components/search/SearchArtistResultContent/SearchArtistResultContent.tsx
@@ -5,12 +5,14 @@ import styles from "./SearchArtistResultContent.module.css";
 const SearchArtistResultContent = ({
   result,
   url,
+  style,
 }: {
   result: DeezerArtist;
   url: string;
+  style: string;
 }) => {
   return (
-    <div className={styles.artistInfo}>
+    <div className={style === "grid" ? styles.artistInfoGrid : styles.artistInfo}>
       <Link href={`/${url}/${result.id}`}>
         <Image
           src={result.picture_xl || "/images/defaultsong.png"}
@@ -18,9 +20,10 @@ const SearchArtistResultContent = ({
           width={180}
           height={180}
         />
-
-        <p>{result.name}</p>
       </Link>
+      <div>
+        <p>{result.name}</p>
+      </div>
     </div>
   );
 };

--- a/src/components/search/SearchContent/SearchContent.module.css
+++ b/src/components/search/SearchContent/SearchContent.module.css
@@ -1,16 +1,42 @@
-.songInfo {
+.songInfoGrid {
   display: flex;
   flex-direction: column;
 }
 
-.songImage {
+.songInfoGrid img {
   border-radius: 10px;
   box-shadow: 0px 0px 15px -5px #777777;
   width: 100%;
   height: 100%;
 }
 
-.songInfo > p {
+.songInfoGrid > p {
   margin: 0.3rem 0;
   line-height: 1;
+}
+
+.songInfo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border-top: solid rgb(116, 116, 116) 0.05rem;
+  border-bottom: solid rgb(116, 116, 116) 0.05rem;
+}
+
+.songInfo + .songInfo {
+  border-top: none;
+}
+
+.songInfo img {
+  border-radius: 10px;
+  box-shadow: 0px 0px 15px -5px #777777;
+  width: 100%;
+  height: 100%;
+  margin: 0.5rem 0;
+}
+
+.songInfo p {
+  margin: 0;
+  width: 16rem;
+  text-align: left;
 }

--- a/src/components/search/SearchContent/SearchContent.test.tsx
+++ b/src/components/search/SearchContent/SearchContent.test.tsx
@@ -17,14 +17,14 @@ const mockResult: Result = {
 
 describe("SearchContentコンポーネントのテスト", () => {
   test("アーティスト名が正しく表示されているか", () => {
-    const { getByText } = render(<SearchContent result={mockResult} url="url" />);
+    const { getByText } = render(<SearchContent result={mockResult} url="url" style="grid" />);
 
     //アーティスト名が表示されているか
     expect(getByText("Test Artist")).toBeInTheDocument();
   });
 
   test("曲の画像が正しく表示されているか", () => {
-    const { getByAltText } = render(<SearchContent result={mockResult} url="url" />);
+    const { getByAltText } = render(<SearchContent result={mockResult} url="url" style="grid" />);
 
     //srcとaltが正しく表示されているか
     const image = getByAltText("Test Artistの画像");

--- a/src/components/search/SearchContent/SearchContent.tsx
+++ b/src/components/search/SearchContent/SearchContent.tsx
@@ -3,20 +3,24 @@ import Image from "next/image";
 import Link from "next/link";
 import styles from "./SearchContent.module.css";
 
-const SearchContent = ({ result, url }: { result: Result; url: string }) => {
+const SearchContent = ({
+  result,
+  url,
+  style,
+}: {
+  result: Result;
+  url: string;
+  style: string;
+}) => {
   return (
-    <div className={styles.songInfo}>
+    <div className={style === "grid" ? styles.songInfoGrid : styles.songInfo}>
       <Link href={`/${url}/${result.id}`}>
-        <Image
-          src={result.cover}
-          alt={`${result.artist.name}の画像`}
-          width={180}
-          height={180}
-          className={styles.songImage}
-        />
+        <Image src={result.cover} alt={`${result.artist.name}の画像`} width={180} height={180} />
       </Link>
-      <p>{result.title}</p>
-      <p>{result.artist.name}</p>
+      <div>
+        <p>{result.title}</p>
+        <p>{result.artist.name}</p>
+      </div>
     </div>
   );
 };

--- a/src/components/search/SearchKind/SearchKind.module.css
+++ b/src/components/search/SearchKind/SearchKind.module.css
@@ -23,6 +23,20 @@
 }
 
 .hr {
-  border: 0.2rem solid rgb(203, 203, 203);
-  margin: 1rem 0;
+  border: 0.2rem solid rgb(132, 132, 132);
+  margin: 4rem 0;
+}
+
+.viewIcon {
+  font-size: 3rem;
+}
+
+.noneIcon {
+  color: rgb(209, 209, 209);
+  font-size: 3rem;
+}
+
+.icon {
+  text-align: left;
+  margin-top: 1rem;
 }

--- a/src/components/search/SearchKind/SearchKind.tsx
+++ b/src/components/search/SearchKind/SearchKind.tsx
@@ -1,3 +1,5 @@
+import ViewListIcon from "@mui/icons-material/ViewList";
+import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import Link from "next/link";
 import SearchAlbumResult from "../SearchAlbumResult/SearchAlbumResult";
 import SearchArtistResult from "../SearchArtistResult/SearchArtistResult";
@@ -7,10 +9,12 @@ const SearchKind = ({
   freeWord,
   searchTotal,
   kind,
+  style,
 }: {
   freeWord: string;
   searchTotal: string;
   kind: string;
+  style: string;
 }) => {
   return (
     <div className={styles.display}>
@@ -18,7 +22,7 @@ const SearchKind = ({
         {/* クリックすると項目に対応するクエリパラメータを追加 */}
         <li className={styles.kindList}>
           <Link
-            href={`/search?q=${freeWord}&n=${searchTotal}&k=all`}
+            href={`/search?q=${freeWord}&n=${searchTotal}&k=all&s=grid`}
             className={kind === "all" ? styles.active : ""}
           >
             全て
@@ -26,7 +30,7 @@ const SearchKind = ({
         </li>
         <li className={styles.kindList}>
           <Link
-            href={`/search?q=${freeWord}&n=${searchTotal}&k=single`}
+            href={`/search?q=${freeWord}&n=${searchTotal}&k=single&s=grid`}
             className={kind === "single" ? styles.active : ""}
           >
             シングル
@@ -34,7 +38,7 @@ const SearchKind = ({
         </li>
         <li className={styles.kindList}>
           <Link
-            href={`/search?q=${freeWord}&n=${searchTotal}&k=album`}
+            href={`/search?q=${freeWord}&n=${searchTotal}&k=album&s=grid`}
             className={kind === "album" ? styles.active : ""}
           >
             アルバム
@@ -42,7 +46,7 @@ const SearchKind = ({
         </li>
         <li className={styles.kindList}>
           <Link
-            href={`/search?q=${freeWord}&n=${searchTotal}&k=artist`}
+            href={`/search?q=${freeWord}&n=${searchTotal}&k=artist&s=grid`}
             className={kind === "artist" ? styles.active : ""}
           >
             アーティスト
@@ -53,18 +57,98 @@ const SearchKind = ({
       {/* クエリパラメータが合うものを表示 */}
       {kind === "all" && (
         <div>
-          <SearchResult freeWord={freeWord} url="music" searchTotal={searchTotal} />
-          <hr className={styles.hr} />
-          <SearchAlbumResult freeWord={freeWord} url="album" />
-          <hr className={styles.hr} />
-          <SearchArtistResult freeWord={freeWord} url="artist" />
+          <div className={styles.icon}>
+            <Link href={`/search?q=${freeWord}&n=${searchTotal}&k=all&s=grid`}>
+              <ViewModuleIcon className={style === "grid" ? styles.viewIcon : styles.noneIcon} />
+            </Link>
+
+            <Link href={`/search?q=${freeWord}&n=${searchTotal}&k=all&s=none`}>
+              <ViewListIcon className={style === "grid" ? styles.noneIcon : styles.viewIcon} />
+            </Link>
+          </div>
+          {style === "grid" && (
+            <div>
+              <SearchResult
+                freeWord={freeWord}
+                url="music"
+                searchTotal={searchTotal}
+                style="grid"
+              />
+              <hr className={styles.hr} />
+              <SearchAlbumResult freeWord={freeWord} url="album" style="grid" />
+              <hr className={styles.hr} />
+              <SearchArtistResult freeWord={freeWord} url="artist" style="grid" />
+            </div>
+          )}
+          {style === "none" && (
+            <div>
+              <SearchResult
+                freeWord={freeWord}
+                url="music"
+                searchTotal={searchTotal}
+                style="none"
+              />
+              <hr className={styles.hr} />
+              <SearchAlbumResult freeWord={freeWord} url="album" style="none" />
+              <hr className={styles.hr} />
+              <SearchArtistResult freeWord={freeWord} url="artist" style="none" />
+            </div>
+          )}
         </div>
       )}
       {kind === "single" && (
-        <SearchResult freeWord={freeWord} url="music" searchTotal={searchTotal} />
+        <div>
+          <div className={styles.icon}>
+            <Link href={`/search?q=${freeWord}&n=${searchTotal}&k=single&s=grid`}>
+              <ViewModuleIcon className={style === "grid" ? styles.viewIcon : styles.noneIcon} />
+            </Link>
+
+            <Link href={`/search?q=${freeWord}&n=${searchTotal}&k=single&s=none`}>
+              <ViewListIcon className={style === "grid" ? styles.noneIcon : styles.viewIcon} />
+            </Link>
+          </div>
+
+          {style === "grid" && (
+            <SearchResult freeWord={freeWord} url="music" searchTotal={searchTotal} style="grid" />
+          )}
+
+          {style === "none" && (
+            <SearchResult freeWord={freeWord} url="music" searchTotal={searchTotal} style="none" />
+          )}
+        </div>
       )}
-      {kind === "album" && <SearchAlbumResult freeWord={freeWord} url="album" />}
-      {kind === "artist" && <SearchArtistResult freeWord={freeWord} url="artist" />}
+      {kind === "album" && (
+        <div>
+          <div className={styles.icon}>
+            <Link href={`/search?q=${freeWord}&n=${searchTotal}&k=album&s=grid`}>
+              <ViewModuleIcon className={style === "grid" ? styles.viewIcon : styles.noneIcon} />
+            </Link>
+
+            <Link href={`/search?q=${freeWord}&n=${searchTotal}&k=album&s=none`}>
+              <ViewListIcon className={style === "grid" ? styles.noneIcon : styles.viewIcon} />
+            </Link>
+          </div>
+          {style === "grid" && <SearchAlbumResult freeWord={freeWord} url="album" style="grid" />}
+
+          {style === "none" && <SearchAlbumResult freeWord={freeWord} url="album" style="none" />}
+        </div>
+      )}
+      {kind === "artist" && (
+        <div>
+          <div className={styles.icon}>
+            <Link href={`/search?q=${freeWord}&n=${searchTotal}&k=artist&s=grid`}>
+              <ViewModuleIcon className={style === "grid" ? styles.viewIcon : styles.noneIcon} />
+            </Link>
+
+            <Link href={`/search?q=${freeWord}&n=${searchTotal}&k=artist&s=none`}>
+              <ViewListIcon className={style === "grid" ? styles.noneIcon : styles.viewIcon} />
+            </Link>
+          </div>
+          {style === "grid" && <SearchArtistResult freeWord={freeWord} url="artist" style="grid" />}
+
+          {style === "none" && <SearchArtistResult freeWord={freeWord} url="artist" style="none" />}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/search/SearchResult/SearchResult.tsx
+++ b/src/components/search/SearchResult/SearchResult.tsx
@@ -8,10 +8,12 @@ const SearchResult = async ({
   freeWord,
   url,
   searchTotal,
+  style,
 }: {
   freeWord: string;
   url: string;
   searchTotal: string;
+  style: string;
 }) => {
   //関数を使用して検索結果を取得
   const res = await getSearchSongs(freeWord);
@@ -22,9 +24,9 @@ const SearchResult = async ({
       <div>
         <SearchTotal searchTotal={searchTotal} name="シングル" />
       </div>
-      <div className={styles.songGroup}>
+      <div className={style === "grid" ? styles.songGroup : styles.none}>
         {results.map((result) => {
-          return <SearchContent key={result.id} result={result} url={url} />;
+          return <SearchContent key={result.id} result={result} url={url} style={style} />;
         })}
       </div>
     </>

--- a/src/components/search/SearchTotal/SearchTotal.module.css
+++ b/src/components/search/SearchTotal/SearchTotal.module.css
@@ -1,6 +1,6 @@
 .total {
   width: 9rem;
-  margin: 2em 1em 1em 1em;
+  margin: 1em 1em 1em 1em;
   text-align: left;
   border-bottom: 0.3rem solid #c0ffe7;
 }

--- a/src/hooks/top/useFreeWordSearch.ts
+++ b/src/hooks/top/useFreeWordSearch.ts
@@ -53,7 +53,7 @@ export const useFreeWordSearch: UseFreeWordSearch = () => {
       const data = await response.json();
 
       //useRouterで検索結果ページに移動(クエリパラメータに検索ワードと検索数)
-      router.push(`/search?q=${freeWord}&n=${data.totalResults}&k=all`);
+      router.push(`/search?q=${freeWord}&n=${data.totalResults}&k=all&s=grid`);
     } catch (error) {
       console.error(error);
       setError("サーバーエラーが発生しました");


### PR DESCRIPTION
## 概要 :bulb:

- あいまい検索結果の表示の切り替えの部分を実装
- 各コンポーネントの修正

![スクリーンショット 2024-11-25 113807](https://github.com/user-attachments/assets/08b1eff2-7f96-434b-a2a6-9a1bb650bee5)

![スクリーンショット 2024-11-25 113818](https://github.com/user-attachments/assets/62761975-cb17-40a4-9db6-e80583f0703f)



## 観点 :eye:

### hooks/top/useFreeWordSearchを修正
- クエリパラメータを追加

### app/search/pageを修正
- 追加したクエリパラメータをpropsとしてSearchKindに渡す。

### SearchKindコンポーネントを修正
- 受け取ったクエリパラメータを初期値とするcssを記述
- ボタンを押したときにcssが変更されるように修正


### その他
- SearchKindコンポーネントからしたのコンポーネントを修正


## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [x] 特定の個人・団体名などを使用していないか
- [x] 接続情報など秘密情報が含まれていないか
- [x] ログに個人情報等が含まれていないか
- [x] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
