### PR TITLE
お気に入り楽曲編集ページを作成

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["e-cdns-images.dzcdn.net"],
+    domains: ["cdn-images.dzcdn.net"],
   },
 };
 

--- a/src/app/mypage/favoritesong/edit/page.module.css
+++ b/src/app/mypage/favoritesong/edit/page.module.css
@@ -1,0 +1,5 @@
+.editMessage {
+  text-align: center;
+  margin-top: 0.5rem;
+  font-size: 1rem;
+}

--- a/src/app/mypage/favoritesong/edit/page.tsx
+++ b/src/app/mypage/favoritesong/edit/page.tsx
@@ -1,0 +1,54 @@
+import UnauthorizedAccess from "@/components/UnauthorizedAccess/UnauthorizedAccess";
+import FavoriteSongsEditContainer from "@/components/mypage/FavoriteSongsEditContainer/FavoriteSongsEditContainer";
+import MenuHeader from "@/components/mypage/MenuHeader/MenuHeader";
+import BreadList from "@/components/top/BreadList/BreadList";
+import type { DeezerSong } from "@/types/deezer";
+import { checkLoggedInServer, getFavoriteSongs, getSong } from "@/utils/apiFunc";
+import { getTokenFromCookie } from "@/utils/getTokenFromCookie";
+import styles from "./page.module.css";
+
+type favoriteSong = {
+  songId: number;
+  updatedAt: Date;
+};
+
+const FavoriteSongs = async () => {
+  // cookieからtokenを取得し、ログインしているか確認する
+  const token = getTokenFromCookie();
+  const isLoggedin = await checkLoggedInServer(token);
+
+  if (!isLoggedin) {
+    return <UnauthorizedAccess />;
+  }
+
+  // DBからお気に入り楽曲を取得する
+  const favoriteSongs: { resultData: favoriteSong[] } = await getFavoriteSongs(token);
+
+  // お気に入り楽曲の楽曲idをもとに、楽曲情報を取得してデータに加える
+  const favoriteSongsData = await Promise.all(
+    favoriteSongs.resultData.map(async (song) => {
+      const songData: { resSongData: DeezerSong } = await getSong(song.songId);
+      return { ...song, songData: songData.resSongData };
+    }),
+  );
+
+  return (
+    <div>
+      <BreadList
+        bread={[
+          { link: "/", title: "TOP" },
+          { link: "/mypage", title: "マイページ" },
+          { link: "/mypage/favoritesong", title: "お気に入り楽曲" },
+          { link: "/mypage/favoritesong/edit", title: "編集" },
+        ]}
+      />
+      <MenuHeader title="お気に入り楽曲" />
+      <div className={styles.editMessage}>
+        <p>解除するアイテムを選択してください</p>
+      </div>
+      <FavoriteSongsEditContainer songsInfo={favoriteSongsData} />
+    </div>
+  );
+};
+
+export default FavoriteSongs;

--- a/src/components/mypage/FavoriteSongsContainer/FavoriteSongsContainer.tsx
+++ b/src/components/mypage/FavoriteSongsContainer/FavoriteSongsContainer.tsx
@@ -29,6 +29,10 @@ const FavoriteSongsContainer = ({ songsInfo }: FavoriteSongsContainerProps) => {
 
   const songData = ascFlag ? ascSongData : descSongData;
 
+  if (songsInfo.length === 0) {
+    return <SongList songs={[]} url="music" errorMessage="お気に入り曲は登録されていません" />;
+  }
+
   return (
     <>
       <SortButtons label="登録日" onSortChange={(flag) => setAscFlag(flag)} />

--- a/src/components/mypage/FavoriteSongsEditContainer/FavoriteSongsEditContainer.module.css
+++ b/src/components/mypage/FavoriteSongsEditContainer/FavoriteSongsEditContainer.module.css
@@ -1,0 +1,32 @@
+.actionButtonContainer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+  margin-right: 1rem;
+}
+
+.removeFavoriteButtonContainer {
+  margin: 1rem 0;
+  display: flex;
+  justify-content: center;
+}
+
+.removeFavoriteButton {
+  font-size: 16px;
+  color: white;
+  background-color: black;
+  padding: 5px;
+  border: none;
+  border-radius: 10px;
+  height: 40px;
+  width: 90%;
+  max-width: 200px;
+  cursor: pointer;
+}
+
+.removeFavoriteButton:disabled {
+  font-size: 16px;
+  color: white;
+  background-color: #d5d5d5;
+}

--- a/src/components/mypage/FavoriteSongsEditContainer/FavoriteSongsEditContainer.tsx
+++ b/src/components/mypage/FavoriteSongsEditContainer/FavoriteSongsEditContainer.tsx
@@ -1,0 +1,71 @@
+"use client";
+import type { DeezerSong } from "@/types/deezer";
+import { deleteFavoriteSongs } from "@/utils/favoriteSong";
+import CancelIcon from "@mui/icons-material/Cancel";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import ActionButton from "../ActionButton/ActionButton";
+import SelectableSongList from "../SelectableSongList/SelectableSongList";
+import styles from "./FavoriteSongsEditContainer.module.css";
+
+type FavoriteSongsEditContainerProps = {
+  songsInfo: {
+    songId: number;
+    updatedAt: Date;
+    songData: DeezerSong;
+  }[];
+};
+
+const FavoriteSongsEditContainer = ({ songsInfo }: FavoriteSongsEditContainerProps) => {
+  const router = useRouter();
+  // 選択されている音楽を管理, 登録解除ボタンのdisabledプロパティを管理
+  const [selectedSongs, setSelectedSongs] = useState<number[]>([]);
+  const [isButtonDisabled, setButtonDisabled] = useState<boolean>(true);
+
+  const handleCheckboxChange = (id: number, isChecked: boolean) => {
+    setSelectedSongs((prev) => {
+      // isCheckedがtrueのとき楽曲idを追加し、falseのとき除外する
+      const newSelectedSongs = isChecked ? [...prev, id] : prev.filter((songId) => songId !== id);
+
+      // 音楽が選択されていないとき、解除ボタンを無効化する
+      setButtonDisabled(!newSelectedSongs.length);
+      return newSelectedSongs;
+    });
+  };
+
+  const handleDisableButtonClick = async () => {
+    await deleteFavoriteSongs(selectedSongs);
+    // router.refresh()後に state を保持したくないので初期値をセットする
+    setSelectedSongs([]);
+    setButtonDisabled(true);
+    router.refresh();
+  };
+
+  const songData = songsInfo.map((song) => song.songData);
+
+  return (
+    <>
+      <div className={styles.actionButtonContainer}>
+        <ActionButton name="キャンセル" icon={<CancelIcon />} url="/mypage/favoritesong" />
+      </div>
+      <SelectableSongList
+        songs={songData}
+        selectedSongs={selectedSongs}
+        onChange={handleCheckboxChange}
+        errorMessage="お気に入り曲は登録されていません"
+      />
+      <div className={styles.removeFavoriteButtonContainer}>
+        <button
+          type="button"
+          className={styles.removeFavoriteButton}
+          disabled={isButtonDisabled}
+          onClick={handleDisableButtonClick}
+        >
+          お気に入り登録解除
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default FavoriteSongsEditContainer;

--- a/src/components/mypage/FavoriteSongsEditContainer/FavoriteSongsEditContainer.tsx
+++ b/src/components/mypage/FavoriteSongsEditContainer/FavoriteSongsEditContainer.tsx
@@ -20,7 +20,7 @@ const FavoriteSongsEditContainer = ({ songsInfo }: FavoriteSongsEditContainerPro
   const router = useRouter();
   // 選択されている音楽を管理, 登録解除ボタンのdisabledプロパティを管理
   const [selectedSongs, setSelectedSongs] = useState<number[]>([]);
-  const [isButtonDisabled, setButtonDisabled] = useState<boolean>(true);
+  const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(true);
 
   const handleCheckboxChange = (id: number, isChecked: boolean) => {
     setSelectedSongs((prev) => {
@@ -28,7 +28,7 @@ const FavoriteSongsEditContainer = ({ songsInfo }: FavoriteSongsEditContainerPro
       const newSelectedSongs = isChecked ? [...prev, id] : prev.filter((songId) => songId !== id);
 
       // 音楽が選択されていないとき、解除ボタンを無効化する
-      setButtonDisabled(!newSelectedSongs.length);
+      setIsButtonDisabled(!newSelectedSongs.length);
       return newSelectedSongs;
     });
   };
@@ -37,7 +37,7 @@ const FavoriteSongsEditContainer = ({ songsInfo }: FavoriteSongsEditContainerPro
     await deleteFavoriteSongs(selectedSongs);
     // router.refresh()後に state を保持したくないので初期値をセットする
     setSelectedSongs([]);
-    setButtonDisabled(true);
+    setIsButtonDisabled(true);
     router.refresh();
   };
 

--- a/src/components/mypage/SelectableSongList/SelectableSongList.module.css
+++ b/src/components/mypage/SelectableSongList/SelectableSongList.module.css
@@ -1,0 +1,17 @@
+.songListContainer {
+  margin: 1rem 0;
+  padding: 0 1rem;
+}
+
+.songListContainer > ul {
+  list-style-type: none;
+}
+
+.songListContainer li:last-child {
+  border-bottom: 1px solid lightgray;
+}
+
+.noSongsMessage {
+  text-align: center;
+  color: gray;
+}

--- a/src/components/mypage/SelectableSongList/SelectableSongList.test.tsx
+++ b/src/components/mypage/SelectableSongList/SelectableSongList.test.tsx
@@ -1,0 +1,68 @@
+import type { DeezerSong } from "@/types/deezer";
+import { render, screen } from "@testing-library/react";
+import SelectableSongList from "./SelectableSongList";
+
+const mockSong: DeezerSong = {
+  id: 111,
+  title: "分針を噛む",
+  cover_xl: "example.jpg",
+  release_date: "2024-10-17",
+  artist: {
+    id: 222,
+    name: "ずっと真昼でいいのに",
+  },
+  album: {
+    id: 333,
+    title: "誤った真実からの就寝",
+  },
+};
+
+describe("SelectableSongListコンポーネントのテスト", () => {
+  const mockFn = jest.fn();
+
+  test("楽曲がない場合、メッセージを表示すること", () => {
+    render(
+      <SelectableSongList
+        songs={[]}
+        selectedSongs={[]}
+        onChange={mockFn}
+        errorMessage="お気に入り曲は登録されていません"
+      />,
+    );
+    expect(screen.getByText("お気に入り曲は登録されていません")).toBeInTheDocument();
+  });
+
+  test("楽曲が1つある場合、1つのSongListItemを表示すること", () => {
+    render(
+      <SelectableSongList
+        songs={[mockSong]}
+        selectedSongs={[]}
+        onChange={mockFn}
+        errorMessage="お気に入り曲は登録されていません"
+      />,
+    );
+    expect(screen.getByText("分針を噛む")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(screen.getByRole("checkbox")).toHaveAttribute("value", "111");
+  });
+
+  test("複数の楽曲がある場合、複数のSongListItemを表示する", () => {
+    const songs = [mockSong, { ...mockSong, id: 555, title: "勘鈍くて悔しいわ" }];
+    render(
+      <SelectableSongList
+        songs={songs}
+        selectedSongs={[]}
+        onChange={mockFn}
+        errorMessage="お気に入り曲は登録されていません"
+      />,
+    );
+
+    expect(screen.getByText("分針を噛む")).toBeInTheDocument();
+    expect(screen.getByText("勘鈍くて悔しいわ")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+
+    const links = screen.getAllByRole("checkbox");
+    expect(links[0]).toHaveAttribute("value", "111");
+    expect(links[1]).toHaveAttribute("value", "555");
+  });
+});

--- a/src/components/mypage/SelectableSongList/SelectableSongList.tsx
+++ b/src/components/mypage/SelectableSongList/SelectableSongList.tsx
@@ -1,0 +1,37 @@
+import type { DeezerSong } from "@/types/deezer";
+import SongListItemWithCheckbox from "../SongListItemWithCheckbox/SongListItemWithCheckbox";
+import styles from "./SelectableSongList.module.css";
+
+const SelectableSongList = ({
+  songs,
+  selectedSongs,
+  onChange,
+  errorMessage,
+}: {
+  songs: DeezerSong[];
+  selectedSongs: number[];
+  onChange: (id: number, isChecked: boolean) => void;
+  errorMessage: string;
+}) => {
+  return (
+    <div className={styles.songListContainer}>
+      {songs.length === 0 ? (
+        <p className={styles.noSongsMessage}>{errorMessage}</p>
+      ) : (
+        <ul>
+          {songs.map((song) => (
+            <li key={song.id}>
+              <SongListItemWithCheckbox
+                song={song}
+                checked={selectedSongs.includes(song.id)}
+                onChange={onChange}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default SelectableSongList;

--- a/src/components/mypage/SongListItemWithCheckbox/SongListItemWithCheckbox.module.css
+++ b/src/components/mypage/SongListItemWithCheckbox/SongListItemWithCheckbox.module.css
@@ -1,0 +1,50 @@
+.songItemLabel {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem;
+  margin: 0;
+  border-top: 1px solid lightgray;
+  cursor: pointer;
+}
+
+.songItemLabel:hover {
+  background-color: #dcdcdc79;
+}
+
+.songItemLabel > img {
+  border-radius: 5px;
+  box-shadow: 0px 0px 15px -5px #777777;
+}
+
+.songItemLabel > div {
+  margin-left: 1rem;
+  width: 100%;
+}
+
+.songTitle {
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.artistName {
+  font-size: 0.8rem;
+}
+
+.checkbox {
+  appearance: none;
+  height: 18px;
+  width: 18px;
+  cursor: pointer;
+  border: 1px solid lightgray;
+  border-radius: 2px;
+}
+
+.checkbox:checked {
+  border: 1px solid #222;
+  color: white;
+  background-color: #222;
+}
+
+.checkbox:checked::before {
+  content: "✓";
+}

--- a/src/components/mypage/SongListItemWithCheckbox/SongListItemWithCheckbox.test.tsx
+++ b/src/components/mypage/SongListItemWithCheckbox/SongListItemWithCheckbox.test.tsx
@@ -1,0 +1,44 @@
+import type { DeezerSong } from "@/types/deezer";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SongListItemWithCheckbox from "./SongListItemWithCheckbox";
+
+const mockSong: DeezerSong = {
+  id: 111,
+  title: "分針を噛む",
+  cover_xl: "example.jpg",
+  release_date: "2024-10-17",
+  artist: {
+    id: 222,
+    name: "ずっと真昼でいいのに",
+  },
+  album: {
+    id: 333,
+    title: "誤った真実からの就寝",
+  },
+};
+
+describe("SongListItemWithCheckboxコンポーネントの単体テスト", () => {
+  const mockFn = jest.fn();
+
+  test("受け取ったpropsを反映し、レンダリングされること", () => {
+    render(<SongListItemWithCheckbox song={mockSong} checked={false} onChange={mockFn} />);
+
+    expect(screen.getByRole("img", { name: "分針を噛むのジャケット画像" })).toHaveAttribute(
+      "src",
+      `${mockSong.cover_xl}`,
+    );
+
+    expect(screen.getByText("分針を噛む")).toBeInTheDocument;
+    expect(screen.getByText("ずっと真昼でいいのに")).toBeInTheDocument;
+    expect(screen.getByRole("checkbox")).toHaveAttribute("value", "111");
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+  });
+
+  test("チェックボックスを押下したら、イベントハンドラーが呼ばれること", async () => {
+    render(<SongListItemWithCheckbox song={mockSong} checked={false} onChange={mockFn} />);
+
+    await userEvent.click(screen.getByRole("checkbox"));
+    expect(mockFn).toHaveBeenCalledWith(111, true);
+  });
+});

--- a/src/components/mypage/SongListItemWithCheckbox/SongListItemWithCheckbox.tsx
+++ b/src/components/mypage/SongListItemWithCheckbox/SongListItemWithCheckbox.tsx
@@ -1,0 +1,41 @@
+import type { DeezerSong } from "@/types/deezer";
+import Image from "next/image";
+import styles from "./SongListItemWithCheckbox.module.css";
+
+const SongListItemWithCheckbox = ({
+  song,
+  checked,
+  onChange,
+}: {
+  song: DeezerSong;
+  checked: boolean;
+  onChange: (id: number, isChecked: boolean) => void;
+}) => {
+  return (
+    <label htmlFor={song.id.toString()} className={styles.songItemLabel}>
+      <Image
+        src={song.cover_xl || song.album.cover_xl || ""}
+        alt={`${song.title}のジャケット画像`}
+        width={75}
+        height={75}
+        priority
+      />
+      <div>
+        <p className={styles.songTitle}>{song.title}</p>
+        <p className={styles.artistName}>{song.artist.name}</p>
+      </div>
+      <span>
+        <input
+          type="checkbox"
+          className={styles.checkbox}
+          value={song.id.toString()}
+          id={song.id.toString()}
+          checked={checked}
+          onChange={(e) => onChange(Number(e.target.value), e.target.checked)}
+        />
+      </span>
+    </label>
+  );
+};
+
+export default SongListItemWithCheckbox;


### PR DESCRIPTION
## 概要 :bulb:
**追加**
- SelectableSongListコンポーネント
- SongListItemWithCheckboxコンポーネント
- FavoriteSongEditContainerコンポーネント
- お気に入り楽曲編集ページのpageコンポーネント

**修正**
- お気に入り楽曲ページのpageコンポーネント
=> お気に入り楽曲が登録されていないとき、編集ボタンが表示されないようにしました。
- next.config.mjs
=> deezerAPIから取得する画像のドメインを修正しました。

https://github.com/user-attachments/assets/af8bab61-be22-492b-bf13-e3ef3f52c882

## 観点 :eye:
削除処理の動きが問題ないか確認おねがいします。
1.  お気に入り楽曲ページの編集ボタンを押下すると、編集ページへ遷移する
2. アイテムを選択するとチェックボックスにチェックが入る
3. お気に入り登録ボタンを押下するとチェックされている楽曲がお気に入りから削除される
4. お気に入り編集ページを再レンダリング

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [x] 特定の個人・団体名などを使用していないか
- [x] 接続情報など秘密情報が含まれていないか
- [x] ログに個人情報等が含まれていないか
- [x] ドメインは example.com を使用しているか

## テスト :test_tube:

- SelectableSongListコンポーネント
=> `SelectableSongList.test.tsx`
- SongListItemWithCheckboxコンポーネント
=> `SongListItemWithCheckbox.test.tsx`
## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
