### PR TITLE
ハンバーガーメニュー（ログイン状態の反映）

### DIFF
--- a/src/components/frame/header/HamburgerMenu.module.css
+++ b/src/components/frame/header/HamburgerMenu.module.css
@@ -53,7 +53,8 @@
   color: aquamarine;
 }
 
-.hamburgerinList {
+.hamburgerinList,
+.serverError {
   list-style-type: none;
   display: flex;
   margin-left: 25px;
@@ -65,4 +66,9 @@
 .line {
   border-bottom: 1px solid gray;
   margin: 20px 0;
+}
+
+.serverError {
+  color: red;
+  font-size: 0.8rem;
 }

--- a/src/components/frame/header/HamburgerMenu.test.tsx
+++ b/src/components/frame/header/HamburgerMenu.test.tsx
@@ -2,9 +2,14 @@ import { UseHamburgerOpen } from "@/hooks/header/useHamburgerOpen";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { HamburgerMenu } from "./HamburgerMenu";
 import "@testing-library/jest-dom";
+import { useLogout } from "@/hooks/useLogout";
 
 jest.mock("@/hooks/header/useHamburgerOpen", () => ({
   UseHamburgerOpen: jest.fn(),
+}));
+
+jest.mock("@/hooks/useLogout", () => ({
+  useLogout: jest.fn(),
 }));
 
 jest.mock("next/image", () => {
@@ -21,11 +26,16 @@ jest.mock("next/image", () => {
 describe("ハンバーガーメニューの単体テスト", () => {
   const mockHandleMenuClick = jest.fn();
   const mockHandleLinkClick = jest.fn();
+  const mockLogoutUser = jest.fn().mockResolvedValue(undefined);
   beforeEach(() => {
     (UseHamburgerOpen as jest.Mock).mockReturnValue({
       openMenu: false,
       openMenuClick: mockHandleMenuClick,
       hamburgerLink: mockHandleLinkClick,
+    });
+    (useLogout as jest.Mock).mockReturnValue({
+      logoutUser: mockLogoutUser,
+      serverError: "",
     });
   });
 

--- a/src/components/frame/header/HamburgerMenu.tsx
+++ b/src/components/frame/header/HamburgerMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { UseHamburgerOpen } from "@/hooks/header/useHamburgerOpen";
+import { useLogout } from "@/hooks/useLogout";
 import { fetchUser } from "@/utils/apiFunc";
 import AccountBoxIcon from "@mui/icons-material/AccountBox";
 import HeadphonesIcon from "@mui/icons-material/Headphones";
@@ -21,6 +22,7 @@ import styles from "./HamburgerMenu.module.css";
 export const HamburgerMenu = () => {
   const [user, setUser] = useState<string | null>(null);
   const { openMenu, openMenuClick, hamburgerLink } = UseHamburgerOpen();
+  const { logoutUser, serverError } = useLogout();
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ハンバーガーメニューの開閉により更新
   useEffect(() => {
@@ -32,6 +34,11 @@ export const HamburgerMenu = () => {
     };
     getUser();
   }, [openMenu]);
+
+  const logoutClick = () => {
+    logoutUser();
+    openMenuClick();
+  };
 
   return (
     <>
@@ -111,21 +118,21 @@ export const HamburgerMenu = () => {
                   <PersonIcon fontSize="large" />
                   &nbsp;ユーザー
                 </li>
-                {/* ログイン情報により記載内容変更 */}
                 {user ? (
                   <>
                     <li
                       className={styles.hamburgerinList}
-                      onClick={() => hamburgerLink("/user/logout")}
-                      onKeyDown={() => hamburgerLink("/user/logout")}
+                      onClick={logoutClick}
+                      onKeyDown={logoutClick}
                     >
                       <LogoutIcon fontSize="large" />
                       &nbsp;ログアウト
                     </li>
+                    <p className={styles.serverError}>{serverError}</p>
                     <li
                       className={styles.hamburgerinList}
-                      onClick={() => hamburgerLink("/user/[:id]")}
-                      onKeyDown={() => hamburgerLink("/user/[:id]")}
+                      onClick={() => hamburgerLink(`/user/${user}/info`)}
+                      onKeyDown={() => hamburgerLink(`/user/${user}/info`)}
                     >
                       <AccountBoxIcon fontSize="large" />
                       &nbsp;アカウント情報

--- a/src/components/frame/header/HamburgerMenu.tsx
+++ b/src/components/frame/header/HamburgerMenu.tsx
@@ -17,7 +17,9 @@ import PersonIcon from "@mui/icons-material/Person";
 import PlaylistPlayIcon from "@mui/icons-material/PlaylistPlay";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import { ToastContainer } from "react-toastify";
 import styles from "./HamburgerMenu.module.css";
+import "react-toastify/dist/ReactToastify.css";
 
 export const HamburgerMenu = () => {
   const [user, setUser] = useState<string | null>(null);
@@ -42,6 +44,7 @@ export const HamburgerMenu = () => {
 
   return (
     <>
+      <ToastContainer />
       <div className={styles.hamburgerContainer}>
         {openMenu ? (
           <>

--- a/src/components/frame/header/HamburgerMenu.tsx
+++ b/src/components/frame/header/HamburgerMenu.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { UseHamburgerOpen } from "@/hooks/header/useHamburgerOpen";
+import { fetchUser } from "@/utils/apiFunc";
 import AccountBoxIcon from "@mui/icons-material/AccountBox";
 import HeadphonesIcon from "@mui/icons-material/Headphones";
 import HistoryIcon from "@mui/icons-material/History";
@@ -12,10 +15,24 @@ import PeopleOutlineIcon from "@mui/icons-material/PeopleOutline";
 import PersonIcon from "@mui/icons-material/Person";
 import PlaylistPlayIcon from "@mui/icons-material/PlaylistPlay";
 import Image from "next/image";
+import { useEffect, useState } from "react";
 import styles from "./HamburgerMenu.module.css";
 
 export const HamburgerMenu = () => {
+  const [user, setUser] = useState<string | null>(null);
   const { openMenu, openMenuClick, hamburgerLink } = UseHamburgerOpen();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ハンバーガーメニューの開閉により更新
+  useEffect(() => {
+    const getUser = async () => {
+      const data = await fetchUser();
+      if (data) {
+        setUser(data.id);
+      }
+    };
+    getUser();
+  }, [openMenu]);
+
   return (
     <>
       <div className={styles.hamburgerContainer}>
@@ -95,38 +112,45 @@ export const HamburgerMenu = () => {
                   &nbsp;ユーザー
                 </li>
                 {/* ログイン情報により記載内容変更 */}
-                <li
-                  className={styles.hamburgerinList}
-                  onClick={() => hamburgerLink("/user/login")}
-                  onKeyDown={() => hamburgerLink("/user/login")}
-                >
-                  <LoginIcon fontSize="large" />
-                  &nbsp;ログイン
-                </li>
-                <li
-                  className={styles.hamburgerinList}
-                  onClick={() => hamburgerLink("/user/register")}
-                  onKeyDown={() => hamburgerLink("/user/register")}
-                >
-                  <HowToRegIcon fontSize="large" />
-                  &nbsp;新規登録
-                </li>
-                <li
-                  className={styles.hamburgerinList}
-                  onClick={() => hamburgerLink("/user/logout")}
-                  onKeyDown={() => hamburgerLink("/user/logout")}
-                >
-                  <LogoutIcon fontSize="large" />
-                  &nbsp;ログアウト
-                </li>
-                <li
-                  className={styles.hamburgerinList}
-                  onClick={() => hamburgerLink("/user/[:id]")}
-                  onKeyDown={() => hamburgerLink("/user/[:id]")}
-                >
-                  <AccountBoxIcon fontSize="large" />
-                  &nbsp;アカウント情報
-                </li>
+                {user ? (
+                  <>
+                    <li
+                      className={styles.hamburgerinList}
+                      onClick={() => hamburgerLink("/user/logout")}
+                      onKeyDown={() => hamburgerLink("/user/logout")}
+                    >
+                      <LogoutIcon fontSize="large" />
+                      &nbsp;ログアウト
+                    </li>
+                    <li
+                      className={styles.hamburgerinList}
+                      onClick={() => hamburgerLink("/user/[:id]")}
+                      onKeyDown={() => hamburgerLink("/user/[:id]")}
+                    >
+                      <AccountBoxIcon fontSize="large" />
+                      &nbsp;アカウント情報
+                    </li>
+                  </>
+                ) : (
+                  <>
+                    <li
+                      className={styles.hamburgerinList}
+                      onClick={() => hamburgerLink("/user/login")}
+                      onKeyDown={() => hamburgerLink("/user/login")}
+                    >
+                      <LoginIcon fontSize="large" />
+                      &nbsp;ログイン
+                    </li>
+                    <li
+                      className={styles.hamburgerinList}
+                      onClick={() => hamburgerLink("/user/register")}
+                      onKeyDown={() => hamburgerLink("/user/register")}
+                    >
+                      <HowToRegIcon fontSize="large" />
+                      &nbsp;新規登録
+                    </li>
+                  </>
+                )}
               </ul>
             </div>
           </>

--- a/src/components/mypage/Logout/Logout.tsx
+++ b/src/components/mypage/Logout/Logout.tsx
@@ -1,40 +1,11 @@
 "use client";
+import { useLogout } from "@/hooks/useLogout";
 import LogoutIcon from "@mui/icons-material/Logout";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { toast } from "react-toastify";
 import menuStyles from "../MenuBox/MenuBox.module.css";
 import styles from "./Logout.module.css";
 
 const Logout = () => {
-  const [serverError, setServerError] = useState("");
-  const router = useRouter();
-  const logoutUser = async () => {
-    try {
-      const response = await fetch("/api/user/logout", {
-        method: "POST",
-      });
-
-      if (response.ok) {
-        toast.success("ログアウトが完了しました！", {
-          position: "top-center",
-          autoClose: 1000,
-          closeButton: true,
-          hideProgressBar: true,
-          closeOnClick: true,
-          theme: "colored",
-        });
-        setTimeout(() => {
-          router.push("/");
-        }, 500);
-      } else {
-        toast.error("ログアウトに失敗しました。もう一度お試しください。");
-      }
-    } catch (err) {
-      console.log(err);
-      setServerError("サーバーエラーが発生しました");
-    }
-  };
+  const { logoutUser, serverError } = useLogout();
   return (
     <>
       <button type="button" onClick={logoutUser} className={styles.menuBox}>

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "react-toastify";
+
+type UseLogout = () => {
+  logoutUser: () => Promise<void>;
+  serverError: string;
+};
+
+export const useLogout: UseLogout = () => {
+  const [serverError, setServerError] = useState("");
+  const router = useRouter();
+  const logoutUser = async () => {
+    try {
+      const response = await fetch("/api/user/logout", {
+        method: "POST",
+      });
+
+      if (response.ok) {
+        toast.success("ログアウトが完了しました！", {
+          position: "top-center",
+          autoClose: 1000,
+          closeButton: true,
+          hideProgressBar: true,
+          closeOnClick: true,
+          theme: "colored",
+        });
+        setTimeout(() => {
+          router.push("/");
+        }, 500);
+      } else {
+        toast.error("ログアウトに失敗しました。もう一度お試しください。");
+      }
+    } catch (err) {
+      console.log(err);
+      setServerError("サーバーエラーが発生しました");
+    }
+  };
+
+  return {
+    logoutUser,
+    serverError,
+  };
+};


### PR DESCRIPTION
## 概要 :bulb:

- ハンバーガーメニューでログイン状態の有無により表示内容を変更するよう修正
  - ログアウト時、「ログイン」「新規会員登録」ページへのリンクを表示

![image](https://github.com/user-attachments/assets/7169ba7a-f797-4589-a270-4304b125f016)

---
  - ログイン時、「ログアウト」「会員情報」ページへのリンクを表示
![image](https://github.com/user-attachments/assets/26a31680-92da-4a20-b830-5ae8290c1302)

## 観点 :eye:

### ログイン判定
- fetchUser関数を用いてcookieの情報を取得
- user_idの有無によりログインを判定

### ログアウト処理
- ログアウト処理をカスタムフック化(useLogout)
  - logoutコンポーネント(mypage)修正済み

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
