### PR TITLE
お気に入りの重複登録防止（楽曲、アーティストにおける、ボタンの表示切替）

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["e-cdns-images.dzcdn.net"],
+    domains: ["cdn-images.dzcdn.net"],
   },
 };
 

--- a/src/app/api/favoriteSongs/route.ts
+++ b/src/app/api/favoriteSongs/route.ts
@@ -86,3 +86,39 @@ export const POST = async (req: NextRequest) => {
     return NextResponse.json({ message: "サーバーエラーが発生しました" }, { status: 500 });
   }
 };
+
+export const DELETE = async (req: NextRequest) => {
+  try {
+    // ログインしているか確認する
+    const token = req.cookies.get("token")?.value;
+    if (!token) {
+      return NextResponse.json({ message: "ログインが必要です" }, { status: 401 });
+    }
+
+    const userId = getUserIdFromToken(token);
+    if (!userId) {
+      return NextResponse.json({ message: "認証に失敗しました" }, { status: 401 });
+    }
+
+    // リクエストに削除対象が存在するか確認する
+    const { songIds } = await req.json();
+    if (!songIds.length) {
+      return NextResponse.json({ message: "削除対象の楽曲idが必要です" }, { status: 400 });
+    }
+
+    // DBからお気に入り楽曲を削除する
+    await prisma.favorite_Song.deleteMany({
+      where: {
+        user_id: userId,
+        api_song_id: {
+          in: songIds,
+        },
+      },
+    });
+
+    return NextResponse.json({ message: "お気に入り楽曲の削除に成功しました" }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラーが発生しました" }, { status: 500 });
+  }
+};

--- a/src/app/api/getFavoriteArtistsForFav/route.ts
+++ b/src/app/api/getFavoriteArtistsForFav/route.ts
@@ -13,7 +13,7 @@ export const POST = async (req: NextRequest) => {
     const userId =body.userId.id;
 
     // NOTE: DBからお気に入り楽曲を取得する
-    const favoriteSongs = await prisma.favorite_Song.findMany({
+    const favoriteArtists = await prisma.favorite_Artist.findMany({
       where: {
         user_id: userId,
       },
@@ -21,20 +21,20 @@ export const POST = async (req: NextRequest) => {
         updatedAt: "desc",
       },
       select: {
-        api_song_id: true,
+        api_artist_id: true,
         updatedAt: true,
       },
     });
 
     // NOTE: お気に入り楽曲が登録されていない場合は空の配列を返す
-    if (!favoriteSongs.length) {
+    if (!favoriteArtists.length) {
       return NextResponse.json({ resultData: [] }, { status: 200 });
     }
 
-    const resultData = favoriteSongs.map((song) => {
+    const resultData = favoriteArtists.map((artist) => {
       return {
-        songId: Number(song.api_song_id),
-        updatedAt: song.updatedAt,
+        artistId: Number(artist.api_artist_id),
+        updatedAt: artist.updatedAt,
       };
     });
 

--- a/src/app/api/getFavoriteArtistsForFav/route.ts
+++ b/src/app/api/getFavoriteArtistsForFav/route.ts
@@ -2,15 +2,15 @@ import prisma from "@/lib/prisma";
 import { type NextRequest, NextResponse } from "next/server";
 
 type Body = {
-  userId: {id: string};
-}
+  userId: { id: string };
+};
 
 // お気に入り楽曲の取得
 export const POST = async (req: NextRequest) => {
   try {
     // NOTE: ログインユーザーのidを取得する
-    const body:Body = await req.json();
-    const userId =body.userId.id;
+    const body: Body = await req.json();
+    const userId = body.userId.id;
 
     // NOTE: DBからお気に入り楽曲を取得する
     const favoriteArtists = await prisma.favorite_Artist.findMany({

--- a/src/app/api/getFavoriteSongsForFav/route.ts
+++ b/src/app/api/getFavoriteSongsForFav/route.ts
@@ -2,15 +2,15 @@ import prisma from "@/lib/prisma";
 import { type NextRequest, NextResponse } from "next/server";
 
 type Body = {
-  userId: {id: string};
-}
+  userId: { id: string };
+};
 
 // お気に入り楽曲の取得
 export const POST = async (req: NextRequest) => {
   try {
     // NOTE: ログインユーザーのidを取得する
-    const body:Body = await req.json();
-    const userId =body.userId.id;
+    const body: Body = await req.json();
+    const userId = body.userId.id;
 
     // NOTE: DBからお気に入り楽曲を取得する
     const favoriteSongs = await prisma.favorite_Song.findMany({

--- a/src/app/api/getFavoriteSongsForFav/route.ts
+++ b/src/app/api/getFavoriteSongsForFav/route.ts
@@ -1,16 +1,18 @@
 import prisma from "@/lib/prisma";
-import { getUserIdFromToken } from "@/utils/getUserIdFromToken";
+import { AbsoluteString } from "next/dist/lib/metadata/types/metadata-types";
 import { type NextRequest, NextResponse } from "next/server";
 
 type Body = {
-  userId: string;
+  userId: {id: string};
 }
+
+
 // お気に入り楽曲の取得
-export const GET = async (req: NextRequest) => {
+export const POST = async (req: NextRequest) => {
   try {
     // NOTE: ログインユーザーのidを取得する
     const body:Body = await req.json();
-    const userId =body.userId;
+    const userId =body.userId.id;
 
     // NOTE: DBからお気に入り楽曲を取得する
     const favoriteSongs = await prisma.favorite_Song.findMany({

--- a/src/app/api/getFavoriteSongsForFav/route.ts
+++ b/src/app/api/getFavoriteSongsForFav/route.ts
@@ -1,0 +1,46 @@
+import prisma from "@/lib/prisma";
+import { getUserIdFromToken } from "@/utils/getUserIdFromToken";
+import { type NextRequest, NextResponse } from "next/server";
+
+type Body = {
+  userId: string;
+}
+// お気に入り楽曲の取得
+export const GET = async (req: NextRequest) => {
+  try {
+    // NOTE: ログインユーザーのidを取得する
+    const body:Body = await req.json();
+    const userId =body.userId;
+
+    // NOTE: DBからお気に入り楽曲を取得する
+    const favoriteSongs = await prisma.favorite_Song.findMany({
+      where: {
+        user_id: userId,
+      },
+      orderBy: {
+        updatedAt: "desc",
+      },
+      select: {
+        api_song_id: true,
+        updatedAt: true,
+      },
+    });
+
+    // NOTE: お気に入り楽曲が登録されていない場合は空の配列を返す
+    if (!favoriteSongs.length) {
+      return NextResponse.json({ resultData: [] }, { status: 200 });
+    }
+
+    const resultData = favoriteSongs.map((song) => {
+      return {
+        songId: Number(song.api_song_id),
+        updatedAt: song.updatedAt,
+      };
+    });
+
+    return NextResponse.json({ resultData }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラーが発生しました" }, { status: 500 });
+  }
+};

--- a/src/app/user/[id]/edit/page.test.tsx
+++ b/src/app/user/[id]/edit/page.test.tsx
@@ -12,8 +12,10 @@ jest.mock("next/navigation", () => ({
 describe("Editコンポーネントのテスト", () => {
   test("未ログインの場合はUnauthenticatedコンポーネントが表示されること", async () => {
     render(<Edit />);
-    await waitFor(() =>{
-      expect(screen.getByText(/不正な画面遷移です.*下記ボタンよりログインしてください/),).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/不正な画面遷移です.*下記ボタンよりログインしてください/),
+      ).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "ログインページへ移動" })).toBeInTheDocument();
     });
   });

--- a/src/app/user/[id]/edit/page.test.tsx
+++ b/src/app/user/[id]/edit/page.test.tsx
@@ -12,11 +12,9 @@ jest.mock("next/navigation", () => ({
 describe("Editコンポーネントのテスト", () => {
   test("未ログインの場合はUnauthenticatedコンポーネントが表示されること", async () => {
     render(<Edit />);
-    await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
-
-    expect(
-      screen.getByText(/不正な画面遷移です.*下記ボタンよりログインしてください/),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "ログインページへ移動" })).toBeInTheDocument();
+    await waitFor(() =>{
+      expect(screen.getByText(/不正な画面遷移です.*下記ボタンよりログインしてください/),).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "ログインページへ移動" })).toBeInTheDocument();
+    });
   });
 });

--- a/src/app/user/[id]/info/page.tsx
+++ b/src/app/user/[id]/info/page.tsx
@@ -97,7 +97,7 @@ const Info = () => {
         setServerError(error.message);
       }
 
-      toast.success("編集が完了しました！", {
+      toast.success("退会が完了しました！", {
         position: "top-center",
         autoClose: 1000,
         closeButton: true,

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
@@ -16,9 +16,16 @@
   margin-left: 1rem;
 }
 
-.albumSingleInfo > button {
+.postButton {
   background-color: white;
   border: 1px solid #fc9aff;
+  border-radius: 5px;
+  padding: 0.2rem 0.6rem 0;
+}
+
+.deleteButton {
+  background-color: white;
+  border: 1px solid #a9a9a9;
   border-radius: 5px;
   padding: 0.2rem 0.6rem 0;
 }

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
@@ -2,12 +2,16 @@ import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
 import { fireEvent, render, screen } from "@testing-library/react";
 import AlbumSingleSong from "./AlbumSingleSong";
 
-beforeAll(() => {
-  jest.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => {
-    return Promise.resolve();
-  });
+jest.mock("../../../utils/apiFunc", () => ({
+  fetchUser: jest.fn().mockImplementation(() => "userId"),
+  getFavoriteSongsForFav: jest.fn().mockImplementation(() => ({
+    resultData: [{ songId: 7878479, updatedAt: new Date() }],
+  })),
+}));
 
-  jest.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+beforeAll(() => {
+  jest.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => Promise.resolve());
+  jest.spyOn(HTMLMediaElement.prototype, "pause");
 });
 
 afterAll(() => {
@@ -37,7 +41,7 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
     expect(screen.getByText("プレビューが読み込めません")).toBeInTheDocument();
   });
 
-  test("numの値が9より大きい場合、先頭に0が付かないこと", () => {
+  test("num の値が正しくレンダリングされること", () => {
     render(
       <AlbumAudioProvider>
         <AlbumSingleSong id={1} num={15} title="タイトル" preview="example.com" />
@@ -46,7 +50,7 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
     expect(screen.getByText("15: タイトル")).toBeInTheDocument();
   });
 
-  test("再生ボタンをクリックすると、playメソッドが呼び出されること", () => {
+  test("再生ボタンをクリックすると、playメソッドが呼び出されること", async () => {
     render(
       <AlbumAudioProvider>
         <AlbumSingleSong id={1} num={15} title="タイトル" preview="example.com" />
@@ -59,7 +63,7 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
     expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
   });
 
-  test("停止ボタンをクリックすると、stopメソッドが呼び出されること", () => {
+  test("停止ボタンをクリックすると、pauseメソッドが呼び出されること", async () => {
     render(
       <AlbumAudioProvider>
         <AlbumSingleSong id={1} num={15} title="タイトル" preview="example.com" />

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
@@ -3,9 +3,12 @@
 import { useAlbumAudio } from "@/context/AlbumAudioContext";
 import { savePlayHistory } from "@/utils/history";
 import FavoriteIcon from "@mui/icons-material/Favorite";
+import DoneIcon from '@mui/icons-material/Done';
 import Link from "next/link";
 import AlbumSingleSongAudio from "../AlbumSingleSongAudio/AlbumSingleSongAudio";
 import styles from "./AlbumSingleSong.module.css";
+import { useEffect, useState } from "react";
+import { fetchUser, getFavoriteSongsForFav } from "@/utils/apiFunc";
 
 type AlbumSingleSongProps = {
   id: number;
@@ -14,7 +17,15 @@ type AlbumSingleSongProps = {
   preview: string;
 };
 
+type FavoriteSongs = {
+  resultData :{
+    songId: number,
+    updatedAt: Date
+}[]
+};
+
 const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
+  const [isFav, setIsFav] = useState<boolean>(false);
   // コンテキストからstateを呼び出す
   const { currentlyPlayingId, setCurrentlyPlayingId } = useAlbumAudio();
 
@@ -35,6 +46,23 @@ const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
   // 楽曲をナンバリングするための記述
   const displayNum = num.toString().padStart(2, "0");
 
+    // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
+    const doneFav = async () => {
+      // NOTE: ログイン状態を確認し、userIdを返す
+      const userId:string = await fetchUser();
+      // NOTE: DBからお気に入り楽曲を取得。
+      const favoriteSongs:FavoriteSongs = await getFavoriteSongsForFav(userId);
+      const songIds = favoriteSongs.resultData.map((song) => song.songId);
+      // NOTE: もしfavoriteSongsのなかのsongIdとidに、一致するものがあればisFavをtrueにする
+      if(songIds.includes(id)) {
+        setIsFav(true);
+      }
+    };
+  
+    useEffect(()=> {
+      doneFav();
+    }, []);
+
   // 楽曲をお気に入り登録
   const postFavorite = async () => {
     try {
@@ -49,10 +77,38 @@ const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
         return;
       }
       alert("お気に入りに登録されました");
+      setIsFav(true);
     } catch (error) {
       console.error(error);
     }
   };
+
+    // お気に入り楽曲削除
+    const deleteFavorite = async () => {
+      try {
+        const response = await fetch("/api/favoriteSongs", {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            songIds: [id],
+          }),
+        });
+        if (!response.ok) {
+          const error = await response.json();
+          console.error(error);
+          alert(error.message);
+          return;
+        }
+  
+        alert("お気に入り楽曲から削除されました");
+        setIsFav(false);
+      } catch (error) {
+        console.error(error);
+        alert("ネットワークエラーです");
+      }
+    };
 
   return (
     <div className={styles.albumSingleContent}>
@@ -68,17 +124,37 @@ const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
             {displayNum}: {title}
           </Link>
         </p>
-        <button type="button" onClick={postFavorite}>
-          <FavoriteIcon
-            sx={{
-              fontSize: 16,
-              color: "#fc9aff",
-              cursor: "pointer",
-            }}
-            role="img"
-            aria-hidden="false"
-          />
-        </button>
+        {isFav ? (
+          <>
+            <button type="button" onClick={deleteFavorite} className={styles.deleteButton}>
+              <DoneIcon
+                sx={{
+                  fontSize: 16,
+                  color: "#a9a9a9",
+                  cursor: "pointer",
+                }}
+                role="img"
+                aria-hidden="false"
+              />
+            </button>
+          </>
+        )
+          : (
+            <>
+              <button type="button" onClick={postFavorite} className={styles.postButton}>
+                <FavoriteIcon
+                  sx={{
+                    fontSize: 16,
+                    color: "#fc9aff",
+                    cursor: "pointer",
+                  }}
+                  role="img"
+                  aria-hidden="false"
+                />
+              </button>
+            </>
+            )
+        }
       </div>
     </div>
   );

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useAlbumAudio } from "@/context/AlbumAudioContext";
+import { fetchUser, getFavoriteSongsForFav } from "@/utils/apiFunc";
 import { savePlayHistory } from "@/utils/history";
+import DoneIcon from "@mui/icons-material/Done";
 import FavoriteIcon from "@mui/icons-material/Favorite";
-import DoneIcon from '@mui/icons-material/Done';
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import AlbumSingleSongAudio from "../AlbumSingleSongAudio/AlbumSingleSongAudio";
 import styles from "./AlbumSingleSong.module.css";
-import { useEffect, useState } from "react";
-import { fetchUser, getFavoriteSongsForFav } from "@/utils/apiFunc";
 
 type AlbumSingleSongProps = {
   id: number;
@@ -18,10 +18,10 @@ type AlbumSingleSongProps = {
 };
 
 type FavoriteSongs = {
-  resultData :{
-    songId: number,
-    updatedAt: Date
-}[]
+  resultData: {
+    songId: number;
+    updatedAt: Date;
+  }[];
 };
 
 const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
@@ -46,22 +46,23 @@ const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
   // 楽曲をナンバリングするための記述
   const displayNum = num.toString().padStart(2, "0");
 
-    // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
-    const doneFav = async () => {
-      // NOTE: ログイン状態を確認し、userIdを返す
-      const userId:string = await fetchUser();
-      // NOTE: DBからお気に入り楽曲を取得。
-      const favoriteSongs:FavoriteSongs = await getFavoriteSongsForFav(userId);
-      const songIds = favoriteSongs.resultData.map((song) => song.songId);
-      // NOTE: もしfavoriteSongsのなかのsongIdとidに、一致するものがあればisFavをtrueにする
-      if(songIds.includes(id)) {
-        setIsFav(true);
-      }
-    };
-  
-    useEffect(()=> {
-      doneFav();
-    }, []);
+  // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
+  const doneFav = async () => {
+    // NOTE: ログイン状態を確認し、userIdを返す
+    const userId: string = await fetchUser();
+    // NOTE: DBからお気に入り楽曲を取得。
+    const favoriteSongs: FavoriteSongs = await getFavoriteSongsForFav(userId);
+    const songIds = favoriteSongs.resultData.map((song) => song.songId);
+
+    if (songIds.includes(id)) {
+      setIsFav(true);
+    }
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: マウント時のみ実行
+  useEffect(() => {
+    doneFav();
+  }, []);
 
   // 楽曲をお気に入り登録
   const postFavorite = async () => {
@@ -83,32 +84,32 @@ const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
     }
   };
 
-    // お気に入り楽曲削除
-    const deleteFavorite = async () => {
-      try {
-        const response = await fetch("/api/favoriteSongs", {
-          method: "DELETE",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            songIds: [id],
-          }),
-        });
-        if (!response.ok) {
-          const error = await response.json();
-          console.error(error);
-          alert(error.message);
-          return;
-        }
-  
-        alert("お気に入り楽曲から削除されました");
-        setIsFav(false);
-      } catch (error) {
+  // お気に入り楽曲削除
+  const deleteFavorite = async () => {
+    try {
+      const response = await fetch("/api/favoriteSongs", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          songIds: [id],
+        }),
+      });
+      if (!response.ok) {
+        const error = await response.json();
         console.error(error);
-        alert("ネットワークエラーです");
+        alert(error.message);
+        return;
       }
-    };
+
+      alert("お気に入り楽曲から削除されました");
+      setIsFav(false);
+    } catch (error) {
+      console.error(error);
+      alert("ネットワークエラーです");
+    }
+  };
 
   return (
     <div className={styles.albumSingleContent}>
@@ -138,23 +139,21 @@ const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
               />
             </button>
           </>
-        )
-          : (
-            <>
-              <button type="button" onClick={postFavorite} className={styles.postButton}>
-                <FavoriteIcon
-                  sx={{
-                    fontSize: 16,
-                    color: "#fc9aff",
-                    cursor: "pointer",
-                  }}
-                  role="img"
-                  aria-hidden="false"
-                />
-              </button>
-            </>
-            )
-        }
+        ) : (
+          <>
+            <button type="button" onClick={postFavorite} className={styles.postButton}>
+              <FavoriteIcon
+                sx={{
+                  fontSize: 16,
+                  color: "#fc9aff",
+                  cursor: "pointer",
+                }}
+                role="img"
+                aria-hidden="false"
+              />
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/music/AlbumSingles/AlbumSingles.test.tsx
+++ b/src/components/music/AlbumSingles/AlbumSingles.test.tsx
@@ -1,12 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import AlbumSingles from "./AlbumSingles";
 
-beforeAll(() => {
-  jest.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => {
-    return Promise.resolve();
-  });
+jest.mock("../../../utils/apiFunc", () => ({
+  fetchUser: jest.fn().mockImplementation(() => "userId"),
+  getFavoriteSongsForFav: jest.fn().mockImplementation(() => ({
+    resultData: [{ songId: 7878479, updatedAt: new Date() }],
+  })),
+}));
 
-  jest.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+jest.mock("../AlbumSingleSong/AlbumSingleSong", () => {
+  return function MockAlbumSingleSong({ id, title, num }: { id: number; title: string; num: number }) {
+    return (
+      <div data-testid={`song-${id}`}>
+        {num.toString().padStart(2, "0")}: {title}
+      </div>
+    );
+  };
+});
+
+beforeAll(() => {
+  jest.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => Promise.resolve());
+  jest.spyOn(HTMLMediaElement.prototype, "pause");
 });
 
 const AlbumSingleProps = [
@@ -28,7 +42,7 @@ const AlbumSingleProps = [
     id: 3,
     title: "テスト3",
     duration: 200,
-    preview: "example2.com",
+    preview: "example3.com",
     cover_xl: "example2.jpeg",
   },
 ];

--- a/src/components/music/AlbumSingles/AlbumSingles.test.tsx
+++ b/src/components/music/AlbumSingles/AlbumSingles.test.tsx
@@ -9,7 +9,11 @@ jest.mock("../../../utils/apiFunc", () => ({
 }));
 
 jest.mock("../AlbumSingleSong/AlbumSingleSong", () => {
-  return function MockAlbumSingleSong({ id, title, num }: { id: number; title: string; num: number }) {
+  return function MockAlbumSingleSong({
+    id,
+    title,
+    num,
+  }: { id: number; title: string; num: number }) {
     return (
       <div data-testid={`song-${id}`}>
         {num.toString().padStart(2, "0")}: {title}

--- a/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.module.css
+++ b/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.module.css
@@ -1,24 +1,3 @@
-/* .artistInfoAddedFavorite:hover {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: #ff9e9e;
-  color: white;
-  border-radius: 10px;
-  cursor: pointer;
-  padding: 0.4rem 3.5rem;
-  border: white;
-  font-size: 0.9rem;
-  transition: background-color 0.3s ease-in, color 0.3s ease-in, border 0.3s ease-in;
-}
-
-.artistInfoAddedFavorite:hover {
-  background-color: white;
-  color: #ff9e9e;
-  border: 2px solid #ff9e9e;
-} */
-
-
 .artistInfoAddFavorite {
   display: flex;
   background-color: #ff9e9e;

--- a/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.module.css
+++ b/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.module.css
@@ -1,4 +1,4 @@
-.artistInfoContent > button {
+/* .artistInfoAddedFavorite:hover {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -12,8 +12,49 @@
   transition: background-color 0.3s ease-in, color 0.3s ease-in, border 0.3s ease-in;
 }
 
-.artistInfoContent > button:hover {
+.artistInfoAddedFavorite:hover {
   background-color: white;
   color: #ff9e9e;
   border: 2px solid #ff9e9e;
+} */
+
+
+.artistInfoAddFavorite {
+  display: flex;
+  background-color: #ff9e9e;
+  color: white;
+  border: white;
+  border-radius: 10px;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.9rem;
+  padding: 0.4rem 3.5rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease-in, color 0.3s ease-in, border-color 0.3s ease-in;
+}
+
+.artistInfoAddFavorite:hover {
+  background-color: white;
+  color: #ff9e9e;
+  border: 2px solid #ff9e9e;
+}
+
+.artistInfoAddedFavorite {
+  display: flex;
+  background-color: white;
+  color: #a9a9a9;
+  border: 2px solid #a9a9a9;
+  border-radius: 10px;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.9rem;
+  padding: 0.4rem 2.6rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease-in, color 0.3s ease-in, border-color 0.3s ease-in;
+}
+
+.artistInfoAddedFavorite:hover {
+  background-color: #a9a9a9;
+  color: white;
+  border: 2px solid #a9a9a9;
 }

--- a/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.test.tsx
+++ b/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.test.tsx
@@ -1,7 +1,16 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ArtistFavoriteButton from "./ArtistFavoriteButton";
 
-const apiMock = jest.fn();
+jest.mock("../../../utils/apiFunc", () => ({
+  fetchUser: jest.fn().mockImplementation(() => "userId"),
+  getFavoriteArtistsForFav: jest.fn().mockImplementation(() => ({
+    resultData: [{ artistId: 7878479, updatedAt: new Date() }],
+  })),
+}));
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
 
 describe("ArtistFavoriteButtonコンポーネントのテスト", () => {
   test("コンポーネントがpropsを受け取り、画面に表示される", () => {

--- a/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.test.tsx
+++ b/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.test.tsx
@@ -18,5 +18,4 @@ describe("ArtistFavoriteButtonコンポーネントのテスト", () => {
     const button = screen.getByRole("button", { name: "お気に入りに追加" });
     expect(button).toBeInTheDocument();
   });
-
 });

--- a/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.test.tsx
+++ b/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.test.tsx
@@ -10,17 +10,4 @@ describe("ArtistFavoriteButtonコンポーネントのテスト", () => {
     expect(button).toBeInTheDocument();
   });
 
-  test("非同期処理が完了したとき、アラートが表示される", async () => {
-    apiMock.mockResolvedValue({ message: "お気に入りアーティストに追加されました" });
-    window.alert = jest.fn();
-    render(<ArtistFavoriteButton id={88} />);
-
-    const button = screen.getByRole("button", { name: "お気に入りに追加" });
-
-    fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(window.alert).toHaveBeenCalledWith("お気に入りアーティストに追加されました");
-    });
-  });
 });

--- a/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.tsx
+++ b/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.tsx
@@ -1,9 +1,38 @@
 "use client";
 
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import DoneIcon from '@mui/icons-material/Done';
 import styles from "./ArtistFavoriteButton.module.css";
+import { useEffect, useState } from "react";
+import { fetchUser, getFavoriteArtistsForFav } from "@/utils/apiFunc";
+
+type FavoriteArtists = {
+  resultData :{
+    artistId: number,
+    updatedAt: Date
+}[]
+};
 
 const ArtistFavoriteButton = ({ id }: { id: number }) => {
+  const [isFav, setIsFav] = useState<boolean>(false);
+
+  // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
+  const doneFav = async () => {
+    // NOTE: ログイン状態を確認し、userIdを返す
+    const userId:string = await fetchUser();
+    // NOTE: DBからお気に入りアーティストを取得。
+    const favoriteArtists:FavoriteArtists = await getFavoriteArtistsForFav(userId);
+    const ArtistIds = favoriteArtists.resultData.map((artist) => artist.artistId);
+    // NOTE: もしfavoriteSongsのなかのsongIdとidに、一致するものがあればisFavをtrueにする
+    if(ArtistIds.includes(id)) {
+      setIsFav(true);
+    }
+  };
+
+  useEffect(()=> {
+    doneFav();
+  }, []);
+
   const postFavorite = async () => {
     try {
       const response = await fetch("/api/favoriteArtists", {
@@ -24,19 +53,58 @@ const ArtistFavoriteButton = ({ id }: { id: number }) => {
       }
 
       alert("お気に入りアーティストに追加されました");
+      setIsFav(true);
     } catch (error) {
       console.error(error);
       alert("サーバーエラーです");
     }
   };
+
+    // お気に入り楽曲削除
+    const deleteFavorite = async () => {
+      try {
+        const response = await fetch("/api/favoriteSongs", {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            songIds: [id],
+          }),
+        });
+        if (!response.ok) {
+          const error = await response.json();
+          console.error(error);
+          alert(error.message);
+          return;
+        }
+  
+        alert("お気に入りアーティストから削除されました");
+        setIsFav(false);
+      } catch (error) {
+        console.error(error);
+        alert("ネットワークエラーです");
+      }
+    };
+
   return (
     <>
-      <div className={styles.artistInfoContent}>
-        <button type="button" onClick={postFavorite}>
-          <FavoriteBorderIcon />
-          お気に入りに追加
-        </button>
-      </div>
+      {isFav ? (
+        <>
+          <button type="button" className={styles.artistInfoAddedFavorite} onClick={deleteFavorite}>
+            <DoneIcon />
+            お気に入りに追加済み
+          </button>
+        </>
+      ): (
+          <>
+            <button type="button" className={styles.artistInfoAddFavorite} onClick={postFavorite}>
+              <FavoriteBorderIcon />
+              お気に入りに追加
+            </button>
+          </>
+        )
+      }
     </>
   );
 };

--- a/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.tsx
+++ b/src/components/music/ArtistFavoriteButton/ArtistFavoriteButton.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
-import DoneIcon from '@mui/icons-material/Done';
-import styles from "./ArtistFavoriteButton.module.css";
-import { useEffect, useState } from "react";
 import { fetchUser, getFavoriteArtistsForFav } from "@/utils/apiFunc";
+import DoneIcon from "@mui/icons-material/Done";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import { useEffect, useState } from "react";
+import styles from "./ArtistFavoriteButton.module.css";
 
 type FavoriteArtists = {
-  resultData :{
-    artistId: number,
-    updatedAt: Date
-}[]
+  resultData: {
+    artistId: number;
+    updatedAt: Date;
+  }[];
 };
 
 const ArtistFavoriteButton = ({ id }: { id: number }) => {
@@ -19,17 +19,17 @@ const ArtistFavoriteButton = ({ id }: { id: number }) => {
   // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
   const doneFav = async () => {
     // NOTE: ログイン状態を確認し、userIdを返す
-    const userId:string = await fetchUser();
+    const userId: string = await fetchUser();
     // NOTE: DBからお気に入りアーティストを取得。
-    const favoriteArtists:FavoriteArtists = await getFavoriteArtistsForFav(userId);
+    const favoriteArtists: FavoriteArtists = await getFavoriteArtistsForFav(userId);
     const ArtistIds = favoriteArtists.resultData.map((artist) => artist.artistId);
-    // NOTE: もしfavoriteSongsのなかのsongIdとidに、一致するものがあればisFavをtrueにする
-    if(ArtistIds.includes(id)) {
+
+    if (ArtistIds.includes(id)) {
       setIsFav(true);
     }
   };
-
-  useEffect(()=> {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: マウント時のみ実行
+  useEffect(() => {
     doneFav();
   }, []);
 
@@ -60,32 +60,32 @@ const ArtistFavoriteButton = ({ id }: { id: number }) => {
     }
   };
 
-    // お気に入り楽曲削除
-    const deleteFavorite = async () => {
-      try {
-        const response = await fetch("/api/favoriteSongs", {
-          method: "DELETE",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            songIds: [id],
-          }),
-        });
-        if (!response.ok) {
-          const error = await response.json();
-          console.error(error);
-          alert(error.message);
-          return;
-        }
-  
-        alert("お気に入りアーティストから削除されました");
-        setIsFav(false);
-      } catch (error) {
+  // お気に入り楽曲削除
+  const deleteFavorite = async () => {
+    try {
+      const response = await fetch("/api/favoriteSongs", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          songIds: [id],
+        }),
+      });
+      if (!response.ok) {
+        const error = await response.json();
         console.error(error);
-        alert("ネットワークエラーです");
+        alert(error.message);
+        return;
       }
-    };
+
+      alert("お気に入りアーティストから削除されました");
+      setIsFav(false);
+    } catch (error) {
+      console.error(error);
+      alert("ネットワークエラーです");
+    }
+  };
 
   return (
     <>
@@ -96,15 +96,14 @@ const ArtistFavoriteButton = ({ id }: { id: number }) => {
             お気に入りに追加済み
           </button>
         </>
-      ): (
-          <>
-            <button type="button" className={styles.artistInfoAddFavorite} onClick={postFavorite}>
-              <FavoriteBorderIcon />
-              お気に入りに追加
-            </button>
-          </>
-        )
-      }
+      ) : (
+        <>
+          <button type="button" className={styles.artistInfoAddFavorite} onClick={postFavorite}>
+            <FavoriteBorderIcon />
+            お気に入りに追加
+          </button>
+        </>
+      )}
     </>
   );
 };

--- a/src/components/music/ArtistInfo/ArtistInfo.test.tsx
+++ b/src/components/music/ArtistInfo/ArtistInfo.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import ArtistInfo from "./ArtistInfo";
 
+jest.mock("../../../utils/apiFunc", () => ({
+  fetchUser: jest.fn().mockImplementation(() => "userId"),
+  getFavoriteArtistsForFav: jest.fn().mockImplementation(() => ({
+    resultData: [{ artistId: 7878479, updatedAt: new Date() }],
+  })),
+}));
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
 describe("ArtistInfoコンポーネントの単体テスト", () => {
   test("受け取ったpropsを反映し、レンダリングすること", () => {
     render(<ArtistInfo image="example.jpg" name="bluuuue" id={64} />);

--- a/src/components/music/FavoriteButton/FavoriteButton.module.css
+++ b/src/components/music/FavoriteButton/FavoriteButton.module.css
@@ -18,3 +18,24 @@
   color: white;
   border-color: #ff9e9e;
 }
+
+.songInfoAddedFavorite {
+  display: flex;
+  background-color: white;
+  color: #a9a9a9;
+  border: 2px solid #a9a9a9;
+  border-radius: 10px;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.3rem;
+  max-width: 185px;
+  cursor: pointer;
+  transition: background-color 0.3s ease-in, color 0.3s ease-in, border-color 0.3s ease-in;
+}
+
+.songInfoAddedFavorite:hover {
+  background-color: #a9a9a9;
+  color: white;
+  border-color: #a9a9a9;
+}

--- a/src/components/music/FavoriteButton/FavoriteButton.test.tsx
+++ b/src/components/music/FavoriteButton/FavoriteButton.test.tsx
@@ -1,6 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import FavoriteButton from "./FavoriteButton";
 
+jest.mock("../../../utils/apiFunc", () => ({
+  fetchUser: jest.fn().mockImplementation(() => "userId"),
+  getFavoriteSongsForFav: jest.fn().mockImplementation(() => ({
+    resultData: [{ songId: 7878479, updatedAt: new Date() }],
+  })),
+}));
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
 describe("FavoriteButtonコンポーネントのテスト", () => {
   test("idが渡されたとき、ボタンが表示される", () => {
     render(<FavoriteButton id={38384836} />);

--- a/src/components/music/FavoriteButton/FavoriteButton.test.tsx
+++ b/src/components/music/FavoriteButton/FavoriteButton.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import FavoriteButton from "./FavoriteButton";
 
 describe("FavoriteButtonコンポーネントのテスト", () => {

--- a/src/components/music/FavoriteButton/FavoriteButton.tsx
+++ b/src/components/music/FavoriteButton/FavoriteButton.tsx
@@ -5,24 +5,28 @@ import styles from "./FavoriteButton.module.css";
 import { useEffect, useState } from "react";
 import { fetchUser, getFavoriteSongsForFav } from "@/utils/apiFunc";
 
-//FIXME: 使いまわせるように（mypage/favoritesong/page.tsxでも使われておりました） 
-type favoriteSong = {
-  songId: number;
-  updatedAt: Date;
+type FavoriteSongs = {
+  resultData :{
+    songId: number,
+    updatedAt: Date
+}[]
 };
 
 const FavoriteButton = ({ id }: { id: number }) => {
   const [isFav, setIsFav] = useState<boolean>(false);
 
   // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
-  const doneFav= async () => {
+  const doneFav = async () => {
     // NOTE: ログイン状態を確認し、userIdを返す
     const userId:string = await fetchUser();
     // NOTE: DBからお気に入り楽曲を取得。
-    const favoriteSongs = await getFavoriteSongsForFav(userId);
-    console.log(favoriteSongs);
+    const favoriteSongs:FavoriteSongs = await getFavoriteSongsForFav(userId);
+    const songIds = favoriteSongs.resultData.map((song) => song.songId);
+    // NOTE: もしfavoriteSongsのなかのsongIdとidに、一致するものがあればisFavをtrueにする
+    if(songIds.includes(id)) {
+      setIsFav(true);
+    }
   };
-
 
   useEffect(()=> {
     doneFav();

--- a/src/components/music/FavoriteButton/FavoriteButton.tsx
+++ b/src/components/music/FavoriteButton/FavoriteButton.tsx
@@ -2,13 +2,31 @@
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import DoneIcon from '@mui/icons-material/Done';
 import styles from "./FavoriteButton.module.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { fetchUser, getFavoriteSongsForFav } from "@/utils/apiFunc";
+
+//FIXME: 使いまわせるように（mypage/favoritesong/page.tsxでも使われておりました） 
+type favoriteSong = {
+  songId: number;
+  updatedAt: Date;
+};
 
 const FavoriteButton = ({ id }: { id: number }) => {
   const [isFav, setIsFav] = useState<boolean>(false);
 
-  // 初期状態でお気に入り追加済みかどうかを確認し、レンダリング
-  
+  // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
+  const doneFav= async () => {
+    // NOTE: ログイン状態を確認し、userIdを返す
+    const userId:string = await fetchUser();
+    // NOTE: DBからお気に入り楽曲を取得。
+    const favoriteSongs = await getFavoriteSongsForFav(userId);
+    console.log(favoriteSongs);
+  };
+
+
+  useEffect(()=> {
+    doneFav();
+  }, []);
 
   // お気に入り楽曲追加
   const postFavorite = async () => {

--- a/src/components/music/FavoriteButton/FavoriteButton.tsx
+++ b/src/components/music/FavoriteButton/FavoriteButton.tsx
@@ -1,15 +1,16 @@
 "use client";
-import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
-import DoneIcon from '@mui/icons-material/Done';
-import styles from "./FavoriteButton.module.css";
-import { useEffect, useState } from "react";
+
 import { fetchUser, getFavoriteSongsForFav } from "@/utils/apiFunc";
+import DoneIcon from "@mui/icons-material/Done";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import { useEffect, useState } from "react";
+import styles from "./FavoriteButton.module.css";
 
 type FavoriteSongs = {
-  resultData :{
-    songId: number,
-    updatedAt: Date
-}[]
+  resultData: {
+    songId: number;
+    updatedAt: Date;
+  }[];
 };
 
 const FavoriteButton = ({ id }: { id: number }) => {
@@ -18,17 +19,18 @@ const FavoriteButton = ({ id }: { id: number }) => {
   // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
   const doneFav = async () => {
     // NOTE: ログイン状態を確認し、userIdを返す
-    const userId:string = await fetchUser();
+    const userId: string = await fetchUser();
     // NOTE: DBからお気に入り楽曲を取得。
-    const favoriteSongs:FavoriteSongs = await getFavoriteSongsForFav(userId);
+    const favoriteSongs: FavoriteSongs = await getFavoriteSongsForFav(userId);
     const songIds = favoriteSongs.resultData.map((song) => song.songId);
     // NOTE: もしfavoriteSongsのなかのsongIdとidに、一致するものがあればisFavをtrueにする
-    if(songIds.includes(id)) {
+    if (songIds.includes(id)) {
       setIsFav(true);
     }
   };
 
-  useEffect(()=> {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: マウント時のみ実行
+  useEffect(() => {
     doneFav();
   }, []);
 
@@ -95,16 +97,14 @@ const FavoriteButton = ({ id }: { id: number }) => {
             お気に入りに追加済み
           </button>
         </>
-      )
-        : (
-          <>
-            <button type="button" className={styles.songInfoAddFavorite} onClick={postFavorite}>
-              <FavoriteBorderIcon />
-              お気に入りに追加
-            </button>
-          </>
-        )
-      }
+      ) : (
+        <>
+          <button type="button" className={styles.songInfoAddFavorite} onClick={postFavorite}>
+            <FavoriteBorderIcon />
+            お気に入りに追加
+          </button>
+        </>
+      )}
     </>
   );
 };

--- a/src/components/music/FavoriteButton/FavoriteButton.tsx
+++ b/src/components/music/FavoriteButton/FavoriteButton.tsx
@@ -1,8 +1,16 @@
 "use client";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import DoneIcon from '@mui/icons-material/Done';
 import styles from "./FavoriteButton.module.css";
+import { useState } from "react";
 
 const FavoriteButton = ({ id }: { id: number }) => {
+  const [isFav, setIsFav] = useState<boolean>(false);
+
+  // 初期状態でお気に入り追加済みかどうかを確認し、レンダリング
+  
+
+  // お気に入り楽曲追加
   const postFavorite = async () => {
     try {
       const response = await fetch("/api/favoriteSongs", {
@@ -22,6 +30,34 @@ const FavoriteButton = ({ id }: { id: number }) => {
       }
 
       alert("お気に入り楽曲に追加されました");
+      setIsFav(true);
+    } catch (error) {
+      console.error(error);
+      alert("ネットワークエラーです");
+    }
+  };
+
+  // お気に入り楽曲削除
+  const deleteFavorite = async () => {
+    try {
+      const response = await fetch("/api/favoriteSongs", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          songIds: [id],
+        }),
+      });
+      if (!response.ok) {
+        const error = await response.json();
+        console.error(error);
+        alert(error.message);
+        return;
+      }
+
+      alert("お気に入り楽曲から削除されました");
+      setIsFav(false);
     } catch (error) {
       console.error(error);
       alert("ネットワークエラーです");
@@ -30,10 +66,23 @@ const FavoriteButton = ({ id }: { id: number }) => {
 
   return (
     <>
-      <button type="button" className={styles.songInfoAddFavorite} onClick={postFavorite}>
-        <FavoriteBorderIcon />
-        お気に入りに追加
-      </button>
+      {isFav ? (
+        <>
+          <button type="button" className={styles.songInfoAddedFavorite} onClick={deleteFavorite}>
+            <DoneIcon />
+            お気に入りに追加済み
+          </button>
+        </>
+      )
+        : (
+          <>
+            <button type="button" className={styles.songInfoAddFavorite} onClick={postFavorite}>
+              <FavoriteBorderIcon />
+              お気に入りに追加
+            </button>
+          </>
+        )
+      }
     </>
   );
 };

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -393,9 +393,8 @@ export const getFavoriteSongsForFav = async (userId: string) => {
     const res = await fetch("http://localhost:3000/api/getFavoriteSongsForFav", {
       method: "POST",
       cache: "no-cache",
-      body: JSON.stringify({userId}),
-      },
-    );
+      body: JSON.stringify({ userId }),
+    });
 
     if (!res.ok) {
       throw new Error("データが見つかりませんでした");
@@ -413,9 +412,8 @@ export const getFavoriteArtistsForFav = async (userId: string) => {
     const res = await fetch("http://localhost:3000/api/getFavoriteArtistsForFav", {
       method: "POST",
       cache: "no-cache",
-      body: JSON.stringify({userId}),
-      },
-    );
+      body: JSON.stringify({ userId }),
+    });
 
     if (!res.ok) {
       throw new Error("データが見つかりませんでした");

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -406,3 +406,23 @@ export const getFavoriteSongsForFav = async (userId: string) => {
     console.error(error);
   }
 };
+
+// DBからお気に入りアーティストのアーティストIDと更新日を取得する関数（userIdを引数にとる）
+export const getFavoriteArtistsForFav = async (userId: string) => {
+  try {
+    const res = await fetch("http://localhost:3000/api/getFavoriteArtistsForFav", {
+      method: "POST",
+      cache: "no-cache",
+      body: JSON.stringify({userId}),
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error("データが見つかりませんでした");
+    }
+
+    return await res.json();
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -1,7 +1,5 @@
 // 人気新着楽曲を取得する関数
 
-import { JsonWebTokenError } from "jsonwebtoken";
-
 // limitには取得したい件数を入力
 export const getNewSongs = async (limit: number) => {
   try {
@@ -244,10 +242,12 @@ export const getUserPlaylist = async (user_id: string) => {
 export const fetchUser = async () => {
   try {
     const response = await fetch("/api/user/checkLogin");
-    const data = await response.json();
+    console.log(response);
     if (!response.ok) {
-      throw new Error(`エラー: ${response.status} - ${data.message}`);
+      throw new Error("ログイン状態が確認できませんでした");
     }
+    const data = await response.json();
+
     return data;
   } catch (error) {
     console.error(error);
@@ -395,12 +395,13 @@ export const getFavoriteSongsForFav = async (userId: string) => {
       cache: "no-cache",
       body: JSON.stringify({ userId }),
     });
+    const data = await res.json();
 
     if (!res.ok) {
       throw new Error("データが見つかりませんでした");
     }
 
-    return await res.json();
+    return data;
   } catch (error) {
     console.error(error);
   }

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -242,7 +242,6 @@ export const getUserPlaylist = async (user_id: string) => {
 export const fetchUser = async () => {
   try {
     const response = await fetch("/api/user/checkLogin");
-    console.log(response);
     if (!response.ok) {
       throw new Error("ログイン状態が確認できませんでした");
     }

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -391,9 +391,9 @@ export const fetchUserInfo = async () => {
 export const getFavoriteSongsForFav = async (userId: string) => {
   try {
     const res = await fetch("http://localhost:3000/api/getFavoriteSongsForFav", {
-      method: "GET",
+      method: "POST",
       cache: "no-cache",
-      body: JSON.stringify({userId:userId}),
+      body: JSON.stringify({userId}),
       },
     );
 

--- a/src/utils/apiFunc.ts
+++ b/src/utils/apiFunc.ts
@@ -1,4 +1,7 @@
 // 人気新着楽曲を取得する関数
+
+import { JsonWebTokenError } from "jsonwebtoken";
+
 // limitには取得したい件数を入力
 export const getNewSongs = async (limit: number) => {
   try {
@@ -379,6 +382,26 @@ export const fetchUserInfo = async () => {
       throw new Error(`エラー: ${response.status} - ${data.message}`);
     }
     return data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// DBからお気に入り楽曲の楽曲idと更新日を取得する関数（userIdを引数にとる）
+export const getFavoriteSongsForFav = async (userId: string) => {
+  try {
+    const res = await fetch("http://localhost:3000/api/getFavoriteSongsForFav", {
+      method: "GET",
+      cache: "no-cache",
+      body: JSON.stringify({userId:userId}),
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error("データが見つかりませんでした");
+    }
+
+    return await res.json();
   } catch (error) {
     console.error(error);
   }

--- a/test.http
+++ b/test.http
@@ -1,1 +1,0 @@
-http://localhost:3000/api/getFavoriteSongsForFav

--- a/test.http
+++ b/test.http
@@ -1,0 +1,1 @@
+http://localhost:3000/api/getFavoriteSongsForFav


### PR DESCRIPTION
## 概要 :bulb:
- お気に入り登録ボタンを押すと、表示が切り替わります。
- 再度同じページに飛ぶと、ページ内でお気に入りに登録されているかどうか、ログインしているかどうかを確認しボタンの表示が切り替わるようになっています。
- アーティスト、アルバムの楽曲、楽曲詳細、いずれにも上記の機能を実装したのでご確認お願いいたします。

## 観点 :eye:
- ログイン状態により、正しくボタンが表示されるか
（ログイン状態ならお気に入り登録されているかどうかでボタンの表示が変わります。ログアウト状態なら常にボタンは「♡」表示で、押そうとするとログインをするるように促すアラートが表示されます）

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

## 関連する Issue :memo:

## 補足情報 :notes:

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
