### PR TITLE
アルバム詳細の曲にプレイリストボタンを追加

### DIFF
--- a/src/app/album/[id]/@modal/default.tsx
+++ b/src/app/album/[id]/@modal/default.tsx
@@ -1,0 +1,6 @@
+// NOTE: @modalスロットがアクティブでない場合にレンダリングされないようにしています。
+const Default = () => {
+  return null;
+};
+
+export default Default;

--- a/src/app/album/[id]/layout.tsx
+++ b/src/app/album/[id]/layout.tsx
@@ -1,0 +1,18 @@
+// NOTE: playlistページのレイアウトに@modalスロットをpropsとして渡し、childrenと並行してレンダリングさせています。
+const MusicLayout = ({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) => {
+  return (
+    <>
+      {children}
+      {modal}
+      <div id="modal-root" />
+    </>
+  );
+};
+
+export default MusicLayout;

--- a/src/components/music/AddPlaylist/AddPlaylist.test.tsx
+++ b/src/components/music/AddPlaylist/AddPlaylist.test.tsx
@@ -10,7 +10,7 @@ jest.mock("@/utils/apiFunc", () => ({
 
 describe("AddPlaylistの単体テスト", () => {
   test("レンダリングが適切に行われていること", () => {
-    render(<AddPlaylist id={1} />);
+    render(<AddPlaylist id={1} text="プレイリストに追加" />);
     expect(screen.getByRole("button", { name: "プレイリストに追加" })).toBeInTheDocument();
   });
 });

--- a/src/components/music/AddPlaylist/AddPlaylist.tsx
+++ b/src/components/music/AddPlaylist/AddPlaylist.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
 import { SelectAddPlaylist } from "../SelectAddPlaylist/SelectAddPlaylist";
 import styles from "./AddPlaylist.module.css";
 
-export const AddPlaylist = ({ id }: { id: number }) => {
+export const AddPlaylist = ({ id, text }: { id: number; text: string }) => {
   const [user, setUser] = useState<string | null>(null);
   const [playlists, setPlaylists] = useState<Playlist[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
@@ -56,7 +56,7 @@ export const AddPlaylist = ({ id }: { id: number }) => {
     <>
       <button type="button" className={styles.songInfoAddList} onClick={handleAddPlaylist}>
         <CreateNewFolderIcon />
-        <span>プレイリストに追加</span>
+        <span>{text}</span>
       </button>
       {modalOpen && user && (
         <Modal setFunc={setModalOpen}>

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
@@ -21,6 +21,7 @@
   border: 1px solid #fc9aff;
   border-radius: 5px;
   padding: 0.2rem 0.6rem 0;
+  margin-left: 0.5rem;
 }
 
 .deleteButton {
@@ -28,6 +29,7 @@
   border: 1px solid #a9a9a9;
   border-radius: 5px;
   padding: 0.2rem 0.6rem 0;
+  margin-left: 0.5rem;
 }
 
 .play {

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.module.css
@@ -29,3 +29,7 @@
   border-radius: 5px;
   padding: 0.2rem 0.6rem 0;
 }
+
+.play {
+  margin: 0 0 0 auto;
+}

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.test.tsx
@@ -19,7 +19,7 @@ afterAll(() => {
 });
 
 describe("AlbumSingleSongコンポーネントの単体テスト", () => {
-  test("受け取ったpropsを反映し、正しくレンダリングすること", () => {
+  test("受け取ったpropsを反映し、正しくレンダリングすること", async () => {
     render(
       <AlbumAudioProvider>
         <AlbumSingleSong id={1} num={1} title="タイトル" preview="example.com" />
@@ -28,7 +28,10 @@ describe("AlbumSingleSongコンポーネントの単体テスト", () => {
 
     expect(screen.getByText("01: タイトル")).toBeInTheDocument();
     expect(screen.queryByText("プレビューが読み込めません")).not.toBeInTheDocument();
-    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("img", { hidden: false })).toBeInTheDocument();
+    const doneIcon = await screen.findByRole("img", { hidden: false });
+    expect(doneIcon).toBeInTheDocument();
+    expect(doneIcon).toHaveAttribute("aria-hidden", "false");
     expect(screen.getByRole("link")).toHaveAttribute("href", "/music/1");
   });
 

--- a/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
+++ b/src/components/music/AlbumSingleSong/AlbumSingleSong.tsx
@@ -7,6 +7,7 @@ import DoneIcon from "@mui/icons-material/Done";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { AddPlaylist } from "../AddPlaylist/AddPlaylist";
 import AlbumSingleSongAudio from "../AlbumSingleSongAudio/AlbumSingleSongAudio";
 import styles from "./AlbumSingleSong.module.css";
 
@@ -125,6 +126,11 @@ const AlbumSingleSong = ({ id, num, title, preview }: AlbumSingleSongProps) => {
             {displayNum}: {title}
           </Link>
         </p>
+
+        <div className={styles.play}>
+          <AddPlaylist id={id} text="" />
+        </div>
+
         {isFav ? (
           <>
             <button type="button" onClick={deleteFavorite} className={styles.deleteButton}>

--- a/src/components/music/SongInfoContent/SongInfoContent.tsx
+++ b/src/components/music/SongInfoContent/SongInfoContent.tsx
@@ -24,7 +24,7 @@ const SongInfoContent = ({ id, title, artist, image, preview }: SongInfoContentP
             <SongAudio preview={preview} id={id} />
           </div>
           <FavoriteButton id={id} />
-          <AddPlaylist id={id} />
+          <AddPlaylist id={id} text="プレイリストに追加" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要 :bulb:

- アルバム詳細の曲にプレイリストボタンを追加
- AddPlaylistコンポーネントを追加したことによる各コンポーネントの修正

![スクリーンショット 2024-11-28 114334](https://github.com/user-attachments/assets/27d0ea45-57eb-4cd9-9124-61da63394817)


![スクリーンショット 2024-11-28 110837](https://github.com/user-attachments/assets/81a5687f-88df-4c86-bd99-c83a0a5ef432)


## 観点 :eye:

### AddPlaylistコンポーネントを修正
- propsにtextを追加してボタンのテキストを変えられるように修正

### AlbumSingSongコンポーネントを修正
- AddPlaylistコンポーネントを追加。

### その他
- 変更による各テストの修正
- styleの調整


## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [x] 特定の個人・団体名などを使用していないか
- [x] 接続情報など秘密情報が含まれていないか
- [x] ログに個人情報等が含まれていないか
- [x] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
