### PR TITLE
複数曲自動連続再生機能の追加

### DIFF
--- a/src/app/mypage/playlist/[id]/page.module.css
+++ b/src/app/mypage/playlist/[id]/page.module.css
@@ -1,29 +1,3 @@
 .wrapper {
   margin: 1rem;
 }
-
-.playlistList {
-  margin: 2rem 1rem;
-}
-
-.noSongs {
-  font-size: 1.5rem;
-  text-align: center;
-}
-
-.link {
-  display: flex;
-  justify-content: center;
-}
-
-.rankingPageLink {
-  margin: 0 auto;
-  border-bottom: 1px solid black;
-  margin-top: 3rem;
-  padding: 0 3px 1px 3px;
-}
-
-.rankingPageLink:hover {
-  color: #6be3b5;
-  border-bottom: 1px solid #6be3b5;
-}

--- a/src/app/mypage/playlist/[id]/page.tsx
+++ b/src/app/mypage/playlist/[id]/page.tsx
@@ -1,8 +1,9 @@
 import UnauthorizedAccess from "@/components/UnauthorizedAccess/UnauthorizedAccess";
 import { PlaylistHeader } from "@/components/mypage/PlaylistDetail/PlaylistHeader/PlaylistHeader";
-import PickSong from "@/components/special/DetailPage/PlayPickSong/PickSong/PickSong";
+import PlaylistSongButtons from "@/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons";
 import BreadList from "@/components/top/BreadList/BreadList";
 import type { DeezerTrackSong } from "@/types/deezer";
+import SongsAudio from "@/components/music/SongsAudio/SongsAudio";
 import { getTokenFromCookie } from "@/utils/getTokenFromCookie";
 import Link from "next/link";
 import styles from "./page.module.css";
@@ -32,16 +33,19 @@ const Page = async ({ params }: { params: { id: number } }) => {
 
     const playlistInfo: PlaylistInfo = await res.json();
 
-    const response = await fetch("http://localhost:3000/api/getSpecialSongInfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        songs: playlistInfo?.playlistSongs || [],
-      }),
-      cache: "no-store",
-    });
+    const response = await fetch(
+      "http://localhost:3000/api/getSpecialSongInfo",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          songs: playlistInfo?.playlistSongs || [],
+        }),
+        cache: "no-store",
+      }
+    );
 
     const playlistSongs: DeezerTrackSong[] = await response.json();
 
@@ -49,6 +53,23 @@ const Page = async ({ params }: { params: { id: number } }) => {
       playlistSongs.length > 0
         ? playlistSongs.map((playlistSong) => {
             return { api_song_id: playlistSong.id, title: playlistSong.title };
+          })
+        : [];
+
+    const playlistSongsAudio: {
+      preview?: string;
+      id: number;
+      title: string;
+      img: string;
+    }[] =
+      playlistSongs.length > 0
+        ? playlistSongs.map((playlistSong) => {
+            return {
+              preview: playlistSong.preview,
+              id: playlistSong.id,
+              title: playlistSong.title,
+              img: playlistSong.cover_xl,
+            };
           })
         : [];
 
@@ -71,9 +92,12 @@ const Page = async ({ params }: { params: { id: number } }) => {
             playlistId={id}
             playlistSongInfo={playlistSongIds}
           />
+          {playlistSongs.length > 0 ? (
+            <SongsAudio playlistSongsAudio={playlistSongsAudio} />
+          ) : null}
           <div className={styles.playlistList}>
             {playlistSongs.length > 0 ? (
-              <PickSong singles={playlistSongs} />
+              <PlaylistSongButtons singles={playlistSongs} />
             ) : (
               <>
                 <p className={styles.noSongs}>曲を追加しましょう!!</p>

--- a/src/app/mypage/playlist/[id]/page.tsx
+++ b/src/app/mypage/playlist/[id]/page.tsx
@@ -1,12 +1,17 @@
 import UnauthorizedAccess from "@/components/UnauthorizedAccess/UnauthorizedAccess";
 import { PlaylistHeader } from "@/components/mypage/PlaylistDetail/PlaylistHeader/PlaylistHeader";
-import PlaylistSongButtons from "@/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons";
+import { PlaylistSongList } from "@/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList";
 import BreadList from "@/components/top/BreadList/BreadList";
 import type { DeezerTrackSong } from "@/types/deezer";
-import SongsAudio from "@/components/music/SongsAudio/SongsAudio";
 import { getTokenFromCookie } from "@/utils/getTokenFromCookie";
-import Link from "next/link";
 import styles from "./page.module.css";
+
+type PlaylistSongsAudio = {
+  preview?: string;
+  id: number;
+  title: string;
+  img: string;
+};
 
 type PlaylistInfo = {
   playlistTitle: string;
@@ -33,19 +38,16 @@ const Page = async ({ params }: { params: { id: number } }) => {
 
     const playlistInfo: PlaylistInfo = await res.json();
 
-    const response = await fetch(
-      "http://localhost:3000/api/getSpecialSongInfo",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          songs: playlistInfo?.playlistSongs || [],
-        }),
-        cache: "no-store",
-      }
-    );
+    const response = await fetch("http://localhost:3000/api/getSpecialSongInfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        songs: playlistInfo?.playlistSongs || [],
+      }),
+      cache: "no-store",
+    });
 
     const playlistSongs: DeezerTrackSong[] = await response.json();
 
@@ -56,12 +58,7 @@ const Page = async ({ params }: { params: { id: number } }) => {
           })
         : [];
 
-    const playlistSongsAudio: {
-      preview?: string;
-      id: number;
-      title: string;
-      img: string;
-    }[] =
+    const playlistSongsAudio: PlaylistSongsAudio[] =
       playlistSongs.length > 0
         ? playlistSongs.map((playlistSong) => {
             return {
@@ -92,23 +89,7 @@ const Page = async ({ params }: { params: { id: number } }) => {
             playlistId={id}
             playlistSongInfo={playlistSongIds}
           />
-          {playlistSongs.length > 0 ? (
-            <SongsAudio playlistSongsAudio={playlistSongsAudio} />
-          ) : null}
-          <div className={styles.playlistList}>
-            {playlistSongs.length > 0 ? (
-              <PlaylistSongButtons singles={playlistSongs} />
-            ) : (
-              <>
-                <p className={styles.noSongs}>曲を追加しましょう!!</p>
-                <div className={styles.link}>
-                  <Link href="/ranking" className={styles.rankingPageLink}>
-                    人気楽曲ページへ →
-                  </Link>
-                </div>
-              </>
-            )}
-          </div>
+          <PlaylistSongList playlistSongsAudio={playlistSongsAudio} />
         </div>
       </>
     );

--- a/src/components/music/SongsAudio/SongsAudio.module.css
+++ b/src/components/music/SongsAudio/SongsAudio.module.css
@@ -22,11 +22,10 @@
   display: flex;
   margin-top: 3rem;
   margin-bottom: 4rem;
-  padding: 15px;
-  padding-right: 5px;
+  padding: 12px 5px 12px 15px;
   border-radius: 3px;
   box-shadow: 0 2px 10px rgb(177, 176, 176);
-  background-color: rgb(249, 249, 238);
+  background-color: rgb(235, 235, 233);
   align-items: center;
 }
 
@@ -35,7 +34,7 @@
 }
 
 .songIntro > * {
-  background-color: rgb(249, 249, 238);
+  background-color: rgb(235, 235, 233);
 }
 
 .currentTitle {
@@ -49,16 +48,16 @@
   display: flex;
   margin: 0 1rem 0 auto;
   justify-content: center;
-  background-color: rgb(249, 249, 238);
+  background-color: rgb(235, 235, 233);
 }
 
 .controls > button {
-  background-color: rgb(249, 249, 238);
+  background-color: rgb(235, 235, 233);
 }
 
 .preButtonIcon,
 .switchButtonIcon,
 .nextButtonIcon {
   font-size: 2rem;
-  background-color: rgb(249, 249, 238);
+  background-color: rgb(235, 235, 233);
 }

--- a/src/components/music/SongsAudio/SongsAudio.module.css
+++ b/src/components/music/SongsAudio/SongsAudio.module.css
@@ -22,7 +22,8 @@
   display: flex;
   margin-top: 3rem;
   margin-bottom: 4rem;
-  padding: 8px 10px;
+  padding: 15px;
+  padding-right: 5px;
   border-radius: 3px;
   box-shadow: 0 2px 10px rgb(177, 176, 176);
   background-color: rgb(249, 249, 238);

--- a/src/components/music/SongsAudio/SongsAudio.module.css
+++ b/src/components/music/SongsAudio/SongsAudio.module.css
@@ -1,0 +1,63 @@
+.preButton,
+.nextButton,
+.switchButton,
+.playButton {
+  border: none;
+  cursor: pointer;
+}
+
+.playButtons {
+  display: flex;
+  margin-top: 2rem;
+}
+
+.playButton {
+  margin: 0 auto;
+  font-size: 1.4rem;
+  padding: 0.4rem 2.6rem;
+  background-color: rgba(211, 211, 211, 0.231);
+}
+
+.songIntro {
+  display: flex;
+  margin-top: 3rem;
+  margin-bottom: 4rem;
+  padding: 8px 10px;
+  border-radius: 3px;
+  box-shadow: 0 2px 10px rgb(177, 176, 176);
+  background-color: rgb(249, 249, 238);
+  align-items: center;
+}
+
+.songIntro > img {
+  border-radius: 4px;
+}
+
+.songIntro > * {
+  background-color: rgb(249, 249, 238);
+}
+
+.currentTitle {
+  text-align: center;
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-left: 1rem;
+}
+
+.controls {
+  display: flex;
+  margin: 0 1rem 0 auto;
+  justify-content: center;
+  background-color: rgb(249, 249, 238);
+}
+
+.controls > button {
+  background-color: rgb(249, 249, 238);
+}
+
+.preButtonIcon,
+.switchButtonIcon,
+.nextButtonIcon {
+  font-size: 2rem;
+  background-color: rgb(249, 249, 238);
+}

--- a/src/components/music/SongsAudio/SongsAudio.tsx
+++ b/src/components/music/SongsAudio/SongsAudio.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { savePlayHistory } from "@/utils/history";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import SkipNextIcon from "@mui/icons-material/SkipNext";
+import SkipPreviousIcon from "@mui/icons-material/SkipPrevious";
+import PauseIcon from "@mui/icons-material/Pause";
+import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import styles from "./SongsAudio.module.css";
+
+type PlaylistAudioProps = {
+  playlistSongsAudio: {
+    preview?: string;
+    id: number;
+    title: string;
+    img: string;
+  }[];
+};
+
+const SongAudio = ({ playlistSongsAudio }: PlaylistAudioProps) => {
+  // 再生中の楽曲のインデックス
+  const [currentIndex, setCurrentIndex] = useState(0);
+  // 再生中かどうかstateで管理
+  const [isPlaying, setIsPlaying] = useState(false);
+  // 再レンダリングさせたくないので、useRefでaudio要素を参照
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const currentSong = playlistSongsAudio[currentIndex];
+
+  // 曲を再生
+  const handlePlay = async () => {
+    if (audioRef.current) {
+      await audioRef.current.play();
+      setIsPlaying(true);
+      await savePlayHistory(currentSong.id);
+    }
+  };
+
+  // 曲を一時停止
+  const handlePause = () => {
+    if (audioRef.current) {
+      if (isPlaying) {
+        audioRef.current.pause();
+        setIsPlaying(false);
+      } else {
+        audioRef.current.play();
+        setIsPlaying(true);
+      }
+    }
+  };
+
+  // 再生終了後
+  const handleEnded = () => {
+    if (currentIndex < playlistSongsAudio.length - 1) {
+      setCurrentIndex((prevIndex) => prevIndex + 1);
+    } else {
+      setIsPlaying(false);
+      setCurrentIndex(0);
+    }
+  };
+
+  useEffect(() => {
+    const nextPlaying = async () => {
+      if (audioRef.current && isPlaying) {
+        await handlePlay();
+      }
+    };
+    nextPlaying();
+  }, [currentIndex]);
+
+  return (
+    <div>
+      <>
+        <audio src={currentSong.preview} ref={audioRef} onEnded={handleEnded} />
+        <div className={styles.playButtons}>
+          <button
+            type="button"
+            onClick={handlePlay}
+            className={styles.playButton}
+          >
+            ▶ &nbsp;再生
+          </button>
+        </div>
+        <div className={styles.songIntro}>
+          <Image
+            src={playlistSongsAudio[currentIndex].img}
+            alt={`${playlistSongsAudio[currentIndex].title}のジャケット`}
+            height={50}
+            width={50}
+          />
+          <p className={styles.currentTitle}>
+            {playlistSongsAudio[currentIndex].title}
+          </p>
+
+          <div className={styles.controls}>
+            <button
+              type="button"
+              disabled={currentIndex === 0}
+              onClick={() => setCurrentIndex((prevIndex) => prevIndex - 1)}
+              className={styles.preButton}
+            >
+              <SkipPreviousIcon className={styles.preButtonIcon} />
+            </button>
+            <button
+              type="button"
+              onClick={handlePause}
+              className={styles.switchButton}
+            >
+              {isPlaying ? (
+                <PauseIcon className={styles.switchButtonIcon} />
+              ) : (
+                <PlayArrowIcon className={styles.switchButtonIcon} />
+              )}
+            </button>
+            <button
+              type="button"
+              disabled={currentIndex === playlistSongsAudio.length - 1}
+              onClick={() => setCurrentIndex((prevIndex) => prevIndex + 1)}
+              className={styles.nextButton}
+            >
+              <SkipNextIcon className={styles.nextButtonIcon} />
+            </button>
+          </div>
+        </div>
+      </>
+    </div>
+  );
+};
+
+export default SongAudio;

--- a/src/components/music/SongsAudio/SongsAudio.tsx
+++ b/src/components/music/SongsAudio/SongsAudio.tsx
@@ -82,8 +82,8 @@ const SongAudio = ({
           <Image
             src={playlistSongsAudio[currentIndex].img}
             alt={`${playlistSongsAudio[currentIndex].title}のジャケット`}
-            height={50}
-            width={50}
+            height={60}
+            width={60}
           />
           <p className={styles.currentTitle}>{playlistSongsAudio[currentIndex].title}</p>
 

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.module.css
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.module.css
@@ -1,0 +1,30 @@
+.songList {
+  display: flex;
+  align-items: center;
+  margin: 5px 0;
+}
+
+.favoriteButton {
+  background-color: white;
+  border: 1px solid #fc9aff;
+  border-radius: 5px;
+  padding: 0.2rem 0.6rem 0;
+  margin: auto 1rem auto auto;
+}
+
+.playButton {
+  display: flex;
+  align-items: center;
+  background-color: white;
+  border: none;
+  width: 70%;
+}
+
+.playButton > img {
+  border-radius: 4px;
+}
+
+.playButton > p {
+  font-size: 1.2rem;
+  margin-left: 1.2rem;
+}

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
@@ -1,16 +1,29 @@
 "use client";
 
-import type { DeezerTrackSong } from "@/types/deezer";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import Image from "next/image";
+import type { Dispatch, SetStateAction } from "react";
 import styles from "./PlaylistSongButton.module.css";
 
+type PlaylistSongsAudio = {
+  preview?: string;
+  id: number;
+  title: string;
+  img: string;
+};
+
 const PlaylistSongButton = ({
-  pickSong,
+  song,
   index,
+  setCurrentIndex,
+  setIsPlaying,
+  handlePlay,
 }: {
-  pickSong: DeezerTrackSong;
+  song: PlaylistSongsAudio;
   index: number;
+  setCurrentIndex: Dispatch<SetStateAction<number>>;
+  setIsPlaying: Dispatch<SetStateAction<boolean>>;
+  handlePlay: (start_flag: boolean) => Promise<void>;
 }) => {
   const postFavorite = async () => {
     try {
@@ -20,7 +33,7 @@ const PlaylistSongButton = ({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          songId: pickSong.id,
+          songId: song.id,
         }),
       });
       if (!response.ok) {
@@ -36,17 +49,19 @@ const PlaylistSongButton = ({
       alert("ネットワークエラーです");
     }
   };
+
+  const handleIndexPlay = () => {
+    setCurrentIndex(index);
+    setIsPlaying(true);
+    handlePlay(false);
+  };
   return (
     <div className={styles.songList}>
-      <button type="button" className={styles.playButton}>
-        <Image src={pickSong.cover_xl} alt="" height={60} width={60} />
-        <p>{pickSong.title}</p>
+      <button type="button" onClick={handleIndexPlay} className={styles.playButton}>
+        <Image src={song.img} alt="" height={60} width={60} />
+        <p>{song.title}</p>
       </button>
-      <button
-        type="button"
-        onClick={postFavorite}
-        className={styles.favoriteButton}
-      >
+      <button type="button" onClick={postFavorite} className={styles.favoriteButton}>
         <FavoriteIcon
           sx={{
             fontSize: 16,

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { DeezerTrackSong } from "@/types/deezer";
+import FavoriteIcon from "@mui/icons-material/Favorite";
+import Image from "next/image";
+import styles from "./PlaylistSongButton.module.css";
+
+const PlaylistSongButton = ({
+  pickSong,
+  index,
+}: {
+  pickSong: DeezerTrackSong;
+  index: number;
+}) => {
+  const postFavorite = async () => {
+    try {
+      const response = await fetch("/api/favorite/songs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          songId: pickSong.id,
+        }),
+      });
+      if (!response.ok) {
+        const error = await response.json();
+        console.error(error);
+        alert(error.message);
+        return;
+      }
+
+      alert("お気に入り楽曲に追加されました");
+    } catch (error) {
+      console.error(error);
+      alert("ネットワークエラーです");
+    }
+  };
+  return (
+    <div className={styles.songList}>
+      <button type="button" className={styles.playButton}>
+        <Image src={pickSong.cover_xl} alt="" height={60} width={60} />
+        <p>{pickSong.title}</p>
+      </button>
+      <button
+        type="button"
+        onClick={postFavorite}
+        className={styles.favoriteButton}
+      >
+        <FavoriteIcon
+          sx={{
+            fontSize: 16,
+            color: "#fc9aff",
+            cursor: "pointer",
+          }}
+          role="img"
+          aria-hidden="false"
+        />
+      </button>
+    </div>
+  );
+};
+
+export default PlaylistSongButton;

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.module.css
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.module.css
@@ -1,0 +1,8 @@
+.albumSinglesContent {
+  margin-top: 1rem;
+}
+
+.albumSingleSong {
+  border-bottom: 1px solid rgb(203, 203, 203);
+  padding-bottom: 0.2rem;
+}

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
@@ -1,18 +1,41 @@
 "use client";
 
 import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
-import type { DeezerTrackSong } from "@/types/deezer";
+import type { Dispatch, SetStateAction } from "react";
 import PlaylistSongButton from "../PlaylistSongButton/PlaylistSongButton";
 import styles from "./PlaylistSongButtons.module.css";
 
-const PlaylistSongButtons = ({ singles }: { singles: DeezerTrackSong[] }) => {
+type PlaylistSongsAudio = {
+  preview?: string;
+  id: number;
+  title: string;
+  img: string;
+};
+
+const PlaylistSongButtons = ({
+  song,
+  setCurrentIndex,
+  setIsPlaying,
+  handlePlay,
+}: {
+  song: PlaylistSongsAudio[];
+  setCurrentIndex: Dispatch<SetStateAction<number>>;
+  setIsPlaying: Dispatch<SetStateAction<boolean>>;
+  handlePlay: (start_flag: boolean) => Promise<void>;
+}) => {
   return (
     <AlbumAudioProvider>
       <div className={styles.albumSinglesContent}>
-        {singles.map((song: DeezerTrackSong, index: number) => {
+        {song.map((song: PlaylistSongsAudio, index: number) => {
           return (
             <div key={song.id} className={styles.albumSingleSong}>
-              <PlaylistSongButton pickSong={song} index={index} />
+              <PlaylistSongButton
+                song={song}
+                index={index}
+                setCurrentIndex={setCurrentIndex}
+                setIsPlaying={setIsPlaying}
+                handlePlay={handlePlay}
+              />
             </div>
           );
         })}

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
+import type { DeezerTrackSong } from "@/types/deezer";
+import PlaylistSongButton from "../PlaylistSongButton/PlaylistSongButton";
+import styles from "./PlaylistSongButtons.module.css";
+
+const PlaylistSongButtons = ({ singles }: { singles: DeezerTrackSong[] }) => {
+  return (
+    <AlbumAudioProvider>
+      <div className={styles.albumSinglesContent}>
+        {singles.map((song: DeezerTrackSong, index: number) => {
+          return (
+            <div key={song.id} className={styles.albumSingleSong}>
+              <PlaylistSongButton pickSong={song} index={index} />
+            </div>
+          );
+        })}
+      </div>
+    </AlbumAudioProvider>
+  );
+};
+
+export default PlaylistSongButtons;

--- a/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.module.css
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.module.css
@@ -1,0 +1,25 @@
+.playlistList {
+  margin: 2rem 1rem;
+}
+
+.noSongs {
+  font-size: 1.5rem;
+  text-align: center;
+}
+
+.link {
+  display: flex;
+  justify-content: center;
+}
+
+.rankingPageLink {
+  margin: 0 auto;
+  border-bottom: 1px solid black;
+  margin-top: 3rem;
+  padding: 0 3px 1px 3px;
+}
+
+.rankingPageLink:hover {
+  color: #6be3b5;
+  border-bottom: 1px solid #6be3b5;
+}

--- a/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import SongsAudio from "@/components/music/SongsAudio/SongsAudio";
+import PlaylistSongButtons from "@/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons";
+import { savePlayHistory } from "@/utils/history";
+import Link from "next/link";
+import { useRef, useState } from "react";
+import styles from "./PlaylistSongList.module.css";
+
+type PlaylistSongsAudio = {
+  preview?: string;
+  id: number;
+  title: string;
+  img: string;
+};
+
+export const PlaylistSongList = ({
+  playlistSongsAudio,
+}: {
+  playlistSongsAudio: PlaylistSongsAudio[];
+}) => {
+  // 再生中の楽曲のインデックス
+  const [currentIndex, setCurrentIndex] = useState(0);
+  // 再生中かどうかstateで管理
+  const [isPlaying, setIsPlaying] = useState(false);
+  // 再レンダリングさせたくないので、useRefでaudio要素を参照
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const currentSong = playlistSongsAudio[currentIndex];
+
+  // 曲を再生
+  // start_flagがtrueの時、プレイリストの一曲目から再生を始める。falseの時、currentIndexの曲を再生する
+  const handlePlay = async (start_flag: boolean) => {
+    if (audioRef.current) {
+      if (start_flag) {
+        setCurrentIndex(0);
+        await audioRef.current.play();
+        setIsPlaying(true);
+      }
+      await audioRef.current.play();
+      setIsPlaying(true);
+      await savePlayHistory(currentSong.id);
+    }
+  };
+
+  return (
+    <>
+      {playlistSongsAudio.length > 0 ? (
+        <SongsAudio
+          playlistSongsAudio={playlistSongsAudio}
+          currentIndex={currentIndex}
+          setCurrentIndex={setCurrentIndex}
+          isPlaying={isPlaying}
+          setIsPlaying={setIsPlaying}
+          audioRef={audioRef}
+          handlePlay={handlePlay}
+          currentSong={currentSong}
+        />
+      ) : null}
+      <div className={styles.playlistList}>
+        {playlistSongsAudio.length > 0 ? (
+          <PlaylistSongButtons
+            song={playlistSongsAudio}
+            setCurrentIndex={setCurrentIndex}
+            setIsPlaying={setIsPlaying}
+            handlePlay={handlePlay}
+          />
+        ) : (
+          <>
+            <p className={styles.noSongs}>曲を追加しましょう!!</p>
+            <div className={styles.link}>
+              <Link href="/ranking" className={styles.rankingPageLink}>
+                人気楽曲ページへ →
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
## 概要 :bulb:

![image](https://github.com/user-attachments/assets/47928d96-9513-4885-82c8-ace29da291d9)


- プレイリストページに、連続再生機能を追加しました
  - 単曲単位での再生機能を無くしました
  - 再生ボタンを押したら1曲目から再生開始
  - 次の曲(前の曲)へのスキップ機能
  - 停止/再生アイコンを押すと連続再生が停止/停止した箇所から再度再生
  - リストの楽曲を押すとその曲から連続再生が開始


## 観点 :eye:

### PlaylistSongListコンポーネント
- 再生開始関数(handlePlay)、再生状態保持用の状態関数(isPlayling)等をミニプレイヤーとリストで共有するために作成したクライアントコンポーネント
- （処理）
  - handlePlay: 再生ボタン押下時のみ引数にtrueを渡すよう記述。start_flagがtrue時にcurrentIndexを0にして再生開始


### SongsAudioコンポーネント
- 楽曲の再生、停止、終了等の機能を記述
- 再生に関わるアイテムを配置
- （処理）
  - 再生中の楽曲の終了時、再生楽曲のindexがプレイリストの総曲数と一致しなければcurrentIndexを上げ、楽曲を再生することで次の曲へ移る

### PlaylistSongButtonsコンポーネント
- プレイリストの楽曲をmapでPlaylistSongButtonへ渡す(対象楽曲のindexをpropsで渡す)

### PlaylistSongButtonコンポーネント
- プレイリストの楽曲をリスト表示
- 楽曲押下時に、押下した楽曲から連続再生が始まるよう記述
  - 楽曲押下時に、PlaylistSongButtonsから渡されたindexをcurrentIndexに上書きし、再生関数を呼び出すよう記述(handleIndexPlay)


## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
