### PR TITLE
プレイリストシャッフル機能の追加

### DIFF
--- a/src/app/mypage/playlist/[id]/page.tsx
+++ b/src/app/mypage/playlist/[id]/page.tsx
@@ -11,6 +11,7 @@ type PlaylistSongsAudio = {
   id: number;
   title: string;
   img: string;
+  album_id: number;
 };
 
 type PlaylistInfo = {
@@ -38,16 +39,19 @@ const Page = async ({ params }: { params: { id: number } }) => {
 
     const playlistInfo: PlaylistInfo = await res.json();
 
-    const response = await fetch("http://localhost:3000/api/getSpecialSongInfo", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        songs: playlistInfo?.playlistSongs || [],
-      }),
-      cache: "no-store",
-    });
+    const response = await fetch(
+      "http://localhost:3000/api/getSpecialSongInfo",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          songs: playlistInfo?.playlistSongs || [],
+        }),
+        cache: "no-store",
+      }
+    );
 
     const playlistSongs: DeezerTrackSong[] = await response.json();
 
@@ -66,6 +70,7 @@ const Page = async ({ params }: { params: { id: number } }) => {
               id: playlistSong.id,
               title: playlistSong.title,
               img: playlistSong.cover_xl,
+              album_id: playlistSong.album.id,
             };
           })
         : [];

--- a/src/app/mypage/playlist/[id]/page.tsx
+++ b/src/app/mypage/playlist/[id]/page.tsx
@@ -39,19 +39,16 @@ const Page = async ({ params }: { params: { id: number } }) => {
 
     const playlistInfo: PlaylistInfo = await res.json();
 
-    const response = await fetch(
-      "http://localhost:3000/api/getSpecialSongInfo",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          songs: playlistInfo?.playlistSongs || [],
-        }),
-        cache: "no-store",
-      }
-    );
+    const response = await fetch("http://localhost:3000/api/getSpecialSongInfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        songs: playlistInfo?.playlistSongs || [],
+      }),
+      cache: "no-store",
+    });
 
     const playlistSongs: DeezerTrackSong[] = await response.json();
 

--- a/src/components/music/SongsAudio/SongsAudio.module.css
+++ b/src/components/music/SongsAudio/SongsAudio.module.css
@@ -14,9 +14,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 2rem auto 1rem auto;
+  margin: 1.5rem auto 0.5rem auto;
   font-size: 1.2rem;
   padding: 0.5rem 0rem;
+  color: rgb(73, 72, 72);
   background-color: rgba(211, 211, 211, 0.231);
   width: 42%;
 }
@@ -71,18 +72,21 @@
 }
 
 .shuffleButton,
-.reOrderButton {
+.reOrderButton,
+.reOrderDisabled {
   background-color: white;
   border: none;
   margin-right: 1rem;
 }
 
-.reOrderButton {
+.reOrderButton,
+.reOrderDisabled {
   margin-right: 1rem;
 }
 
 .shuffleButton :first-child,
-.reOrderButton :first-child {
+.reOrderButton :first-child,
+.reOrderDisabled :first-child {
   font-size: 2.2rem;
   cursor: pointer;
 }
@@ -90,6 +94,7 @@
 .preButtonIcon:hover,
 .switchButtonIcon:hover,
 .nextButtonIcon:hover,
-.shuffleButton :first-child:hover {
+.shuffleButton :first-child:hover,
+.reOrderButton :first-child:hover {
   color: #92e3c4;
 }

--- a/src/components/music/SongsAudio/SongsAudio.module.css
+++ b/src/components/music/SongsAudio/SongsAudio.module.css
@@ -12,10 +12,14 @@
 }
 
 .playButton {
-  margin: 0 auto;
-  font-size: 1.4rem;
-  padding: 0.4rem 2.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 2rem auto 1rem auto;
+  font-size: 1.2rem;
+  padding: 0.5rem 0rem;
   background-color: rgba(211, 211, 211, 0.231);
+  width: 42%;
 }
 
 .songIntro {

--- a/src/components/music/SongsAudio/SongsAudio.module.css
+++ b/src/components/music/SongsAudio/SongsAudio.module.css
@@ -8,7 +8,6 @@
 
 .playButtons {
   display: flex;
-  margin-top: 2rem;
 }
 
 .playButton {
@@ -25,7 +24,7 @@
 .songIntro {
   display: flex;
   margin-top: 3rem;
-  margin-bottom: 4rem;
+  margin-bottom: 3em;
   padding: 12px 5px 12px 15px;
   border-radius: 3px;
   box-shadow: 0 2px 10px rgb(177, 176, 176);
@@ -64,4 +63,33 @@
 .nextButtonIcon {
   font-size: 2rem;
   background-color: rgb(235, 235, 233);
+}
+
+.orderButton {
+  display: flex;
+  justify-content: right;
+}
+
+.shuffleButton,
+.reOrderButton {
+  background-color: white;
+  border: none;
+  margin-right: 1rem;
+}
+
+.reOrderButton {
+  margin-right: 1rem;
+}
+
+.shuffleButton :first-child,
+.reOrderButton :first-child {
+  font-size: 2.2rem;
+  cursor: pointer;
+}
+
+.preButtonIcon:hover,
+.switchButtonIcon:hover,
+.nextButtonIcon:hover,
+.shuffleButton :first-child:hover {
+  color: #92e3c4;
 }

--- a/src/components/music/SongsAudio/SongsAudio.tsx
+++ b/src/components/music/SongsAudio/SongsAudio.tsx
@@ -16,6 +16,7 @@ type PlaylistAudioProps = {
   id: number;
   title: string;
   img: string;
+  album_id: number
 };
 
 const SongAudio = ({

--- a/src/components/music/SongsAudio/SongsAudio.tsx
+++ b/src/components/music/SongsAudio/SongsAudio.tsx
@@ -16,7 +16,7 @@ type PlaylistAudioProps = {
   id: number;
   title: string;
   img: string;
-  album_id: number
+  album_id: number;
 };
 
 const SongAudio = ({
@@ -70,6 +70,7 @@ const SongAudio = ({
     if (audioRef.current) {
       audioRef.current.pause();
       setIsPlaying(false);
+      // ランダムに生成される0-1の値から0.5を引いて、正ならば1個目と２個目の順序を入れ替える、負ならばそのまま。以降の順序を、同様にして確定させる
       setPlaylistSongs((prevSongs) => [...prevSongs].sort(() => Math.random() - 0.5));
       setCurrentIndex(0);
     }

--- a/src/components/music/SongsAudio/SongsAudio.tsx
+++ b/src/components/music/SongsAudio/SongsAudio.tsx
@@ -161,7 +161,9 @@ const SongAudio = ({
           <button
             type="button"
             onClick={handleReOrder}
-            className={styles.reOrderButton}
+            className={
+              playlistSongs === defaultSongs ? styles.reOrderDisabled : styles.reOrderButton
+            }
             disabled={playlistSongs === defaultSongs}
           >
             <ReorderIcon />

--- a/src/components/mypage/PlaylistDetail/PlaylistHeader/PlaylistHeader.module.css
+++ b/src/components/mypage/PlaylistDetail/PlaylistHeader/PlaylistHeader.module.css
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin-top: 0.5rem;
   margin-right: 1rem;
 }
 .button > :first-child {

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.module.css
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.module.css
@@ -4,26 +4,18 @@
   margin: 5px 0;
 }
 
-.favoriteButton {
-  background-color: white;
-  border: 1px solid #fc9aff;
-  border-radius: 5px;
-  padding: 0.2rem 0.6rem 0;
-  margin: auto 1rem auto auto;
-}
-
 .playButton,
 .currentSong {
   display: flex;
   align-items: center;
   background-color: white;
   border: none;
-  width: 70%;
+  width: 75%;
   cursor: pointer;
 }
 
 .currentSong {
-  margin: 0.3rem 0;
+  margin: 0.2rem 0;
 }
 
 .playButton > img,
@@ -37,6 +29,19 @@
 }
 
 .currentSong > p {
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   margin-left: 1.2rem;
+}
+
+.albumLink {
+  margin: auto 0.5rem auto auto;
+}
+
+.albumLink :first-child {
+  font-size: 1.7rem;
+  color: rgb(187, 185, 185);
+}
+
+.albumLink :first-child:hover {
+  color: #9edbc4;
 }

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.module.css
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.module.css
@@ -12,19 +12,31 @@
   margin: auto 1rem auto auto;
 }
 
-.playButton {
+.playButton,
+.currentSong {
   display: flex;
   align-items: center;
   background-color: white;
   border: none;
   width: 70%;
+  cursor: pointer;
 }
 
-.playButton > img {
+.currentSong {
+  margin: 0.3rem 0;
+}
+
+.playButton > img,
+.currentSong > img {
   border-radius: 4px;
 }
 
 .playButton > p {
+  font-size: 1rem;
+  margin-left: 1.2rem;
+}
+
+.currentSong > p {
   font-size: 1.2rem;
   margin-left: 1.2rem;
 }

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
@@ -2,7 +2,7 @@
 
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import Image from "next/image";
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import styles from "./PlaylistSongButton.module.css";
 
 type PlaylistSongsAudio = {
@@ -17,13 +17,17 @@ const PlaylistSongButton = ({
   index,
   setCurrentIndex,
   setIsPlaying,
+  audioRef,
   handlePlay,
 }: {
   song: PlaylistSongsAudio;
   index: number;
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
-  handlePlay: (start_flag: boolean) => Promise<void>;
+  audioRef: MutableRefObject<HTMLAudioElement | null>;
+  handlePlay: (
+    type: "standard" | "continuous" | "interrupted" | "shuffle"
+  ) => Promise<void>;
 }) => {
   const postFavorite = async () => {
     try {
@@ -51,17 +55,28 @@ const PlaylistSongButton = ({
   };
 
   const handleIndexPlay = () => {
-    setCurrentIndex(index);
-    setIsPlaying(true);
-    handlePlay(false);
+    if (audioRef.current) {
+      setCurrentIndex(index);
+      audioRef.current.currentTime = 0; // 再生時間を0秒に更新
+      setIsPlaying(true);
+      handlePlay("interrupted");
+    }
   };
   return (
     <div className={styles.songList}>
-      <button type="button" onClick={handleIndexPlay} className={styles.playButton}>
+      <button
+        type="button"
+        onClick={handleIndexPlay}
+        className={styles.playButton}
+      >
         <Image src={song.img} alt="" height={60} width={60} />
         <p>{song.title}</p>
       </button>
-      <button type="button" onClick={postFavorite} className={styles.favoriteButton}>
+      <button
+        type="button"
+        onClick={postFavorite}
+        className={styles.favoriteButton}
+      >
         <FavoriteIcon
           sx={{
             fontSize: 16,

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import FavoriteIcon from "@mui/icons-material/Favorite";
+import DoneIcon from "@mui/icons-material/Done";
+import LibraryMusicIcon from "@mui/icons-material/LibraryMusic";
 import Image from "next/image";
+import Link from "next/link";
+import { fetchUser, getFavoriteSongsForFav } from "@/utils/apiFunc";
+import { useState, useEffect } from "react";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import styles from "./PlaylistSongButton.module.css";
 
@@ -10,6 +15,14 @@ type PlaylistSongsAudio = {
   id: number;
   title: string;
   img: string;
+  album_id: number;
+};
+
+type FavoriteSongs = {
+  resultData: {
+    songId: number;
+    updatedAt: Date;
+  }[];
 };
 
 const PlaylistSongButton = ({
@@ -27,8 +40,31 @@ const PlaylistSongButton = ({
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
   audioRef: MutableRefObject<HTMLAudioElement | null>;
-  handlePlay: (type: "standard" | "continuous" | "interrupted") => Promise<void>;
+  handlePlay: (
+    type: "standard" | "continuous" | "interrupted"
+  ) => Promise<void>;
 }) => {
+  const [isFav, setIsFav] = useState<boolean>(false);
+
+  // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
+  const doneFav = async () => {
+    // NOTE: ログイン状態を確認し、userIdを返す
+    const userId: string = await fetchUser();
+    // NOTE: DBからお気に入り楽曲を取得。
+    const favoriteSongs: FavoriteSongs = await getFavoriteSongsForFav(userId);
+    const songIds = favoriteSongs.resultData.map((song) => song.songId);
+    // NOTE: もしfavoriteSongsのなかのsongIdとidに、一致するものがあればisFavをtrueにする
+    if (songIds.includes(song.id)) {
+      setIsFav(true);
+    }
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: マウント時のみ実行
+  useEffect(() => {
+    doneFav();
+  }, []);
+
+  // お気に入り楽曲追加
   const postFavorite = async () => {
     try {
       const response = await fetch("/api/favorite/songs", {
@@ -48,6 +84,34 @@ const PlaylistSongButton = ({
       }
 
       alert("お気に入り楽曲に追加されました");
+      setIsFav(true);
+    } catch (error) {
+      console.error(error);
+      alert("ネットワークエラーです");
+    }
+  };
+
+  // お気に入り楽曲削除
+  const deleteFavorite = async () => {
+    try {
+      const response = await fetch("/api/favorite/songs", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          songIds: [song.id],
+        }),
+      });
+      if (!response.ok) {
+        const error = await response.json();
+        console.error(error);
+        alert(error.message);
+        return;
+      }
+
+      alert("お気に入り楽曲から削除されました");
+      setIsFav(false);
     } catch (error) {
       console.error(error);
       alert("ネットワークエラーです");
@@ -67,26 +131,20 @@ const PlaylistSongButton = ({
       <button
         type="button"
         onClick={handleIndexPlay}
-        className={index === currentIndex ? styles.currentSong : styles.playButton}
+        className={
+          index === currentIndex ? styles.currentSong : styles.playButton
+        }
       >
         {index === currentIndex ? (
-          <Image src={song.img} alt="" height={65} width={65} />
+          <Image src={song.img} alt="" height={60} width={60} />
         ) : (
           <Image src={song.img} alt="" height={50} width={50} />
         )}
         <p>{song.title}</p>
       </button>
-      <button type="button" onClick={postFavorite} className={styles.favoriteButton}>
-        <FavoriteIcon
-          sx={{
-            fontSize: 16,
-            color: "#fc9aff",
-            cursor: "pointer",
-          }}
-          role="img"
-          aria-hidden="false"
-        />
-      </button>
+      <Link href={`/album/${song.album_id}`} className={styles.albumLink}>
+        <LibraryMusicIcon />
+      </Link>
     </div>
   );
 };

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
@@ -15,6 +15,7 @@ type PlaylistSongsAudio = {
 const PlaylistSongButton = ({
   song,
   index,
+  currentIndex,
   setCurrentIndex,
   setIsPlaying,
   audioRef,
@@ -22,6 +23,7 @@ const PlaylistSongButton = ({
 }: {
   song: PlaylistSongsAudio;
   index: number;
+  currentIndex: number;
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
   audioRef: MutableRefObject<HTMLAudioElement | null>;
@@ -62,8 +64,16 @@ const PlaylistSongButton = ({
   };
   return (
     <div className={styles.songList}>
-      <button type="button" onClick={handleIndexPlay} className={styles.playButton}>
-        <Image src={song.img} alt="" height={60} width={60} />
+      <button
+        type="button"
+        onClick={handleIndexPlay}
+        className={index === currentIndex ? styles.currentSong : styles.playButton}
+      >
+        {index === currentIndex ? (
+          <Image src={song.img} alt="" height={65} width={65} />
+        ) : (
+          <Image src={song.img} alt="" height={50} width={50} />
+        )}
         <p>{song.title}</p>
       </button>
       <button type="button" onClick={postFavorite} className={styles.favoriteButton}>

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
@@ -1,12 +1,8 @@
 "use client";
 
-import FavoriteIcon from "@mui/icons-material/Favorite";
-import DoneIcon from "@mui/icons-material/Done";
 import LibraryMusicIcon from "@mui/icons-material/LibraryMusic";
 import Image from "next/image";
 import Link from "next/link";
-import { fetchUser, getFavoriteSongsForFav } from "@/utils/apiFunc";
-import { useState, useEffect } from "react";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import styles from "./PlaylistSongButton.module.css";
 
@@ -16,13 +12,6 @@ type PlaylistSongsAudio = {
   title: string;
   img: string;
   album_id: number;
-};
-
-type FavoriteSongs = {
-  resultData: {
-    songId: number;
-    updatedAt: Date;
-  }[];
 };
 
 const PlaylistSongButton = ({
@@ -40,84 +29,8 @@ const PlaylistSongButton = ({
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
   audioRef: MutableRefObject<HTMLAudioElement | null>;
-  handlePlay: (
-    type: "standard" | "continuous" | "interrupted"
-  ) => Promise<void>;
+  handlePlay: (type: "standard" | "continuous" | "interrupted") => Promise<void>;
 }) => {
-  const [isFav, setIsFav] = useState<boolean>(false);
-
-  // NOTE: DBから取得したお気に入り楽曲とidを比較し、お気に入りボタンの表示を変える
-  const doneFav = async () => {
-    // NOTE: ログイン状態を確認し、userIdを返す
-    const userId: string = await fetchUser();
-    // NOTE: DBからお気に入り楽曲を取得。
-    const favoriteSongs: FavoriteSongs = await getFavoriteSongsForFav(userId);
-    const songIds = favoriteSongs.resultData.map((song) => song.songId);
-    // NOTE: もしfavoriteSongsのなかのsongIdとidに、一致するものがあればisFavをtrueにする
-    if (songIds.includes(song.id)) {
-      setIsFav(true);
-    }
-  };
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: マウント時のみ実行
-  useEffect(() => {
-    doneFav();
-  }, []);
-
-  // お気に入り楽曲追加
-  const postFavorite = async () => {
-    try {
-      const response = await fetch("/api/favorite/songs", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          songId: song.id,
-        }),
-      });
-      if (!response.ok) {
-        const error = await response.json();
-        console.error(error);
-        alert(error.message);
-        return;
-      }
-
-      alert("お気に入り楽曲に追加されました");
-      setIsFav(true);
-    } catch (error) {
-      console.error(error);
-      alert("ネットワークエラーです");
-    }
-  };
-
-  // お気に入り楽曲削除
-  const deleteFavorite = async () => {
-    try {
-      const response = await fetch("/api/favorite/songs", {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          songIds: [song.id],
-        }),
-      });
-      if (!response.ok) {
-        const error = await response.json();
-        console.error(error);
-        alert(error.message);
-        return;
-      }
-
-      alert("お気に入り楽曲から削除されました");
-      setIsFav(false);
-    } catch (error) {
-      console.error(error);
-      alert("ネットワークエラーです");
-    }
-  };
-
   const handleIndexPlay = () => {
     if (audioRef.current) {
       setCurrentIndex(index);
@@ -131,9 +44,7 @@ const PlaylistSongButton = ({
       <button
         type="button"
         onClick={handleIndexPlay}
-        className={
-          index === currentIndex ? styles.currentSong : styles.playButton
-        }
+        className={index === currentIndex ? styles.currentSong : styles.playButton}
       >
         {index === currentIndex ? (
           <Image src={song.img} alt="" height={60} width={60} />

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButton/PlaylistSongButton.tsx
@@ -25,9 +25,7 @@ const PlaylistSongButton = ({
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
   audioRef: MutableRefObject<HTMLAudioElement | null>;
-  handlePlay: (
-    type: "standard" | "continuous" | "interrupted" | "shuffle"
-  ) => Promise<void>;
+  handlePlay: (type: "standard" | "continuous" | "interrupted") => Promise<void>;
 }) => {
   const postFavorite = async () => {
     try {
@@ -64,19 +62,11 @@ const PlaylistSongButton = ({
   };
   return (
     <div className={styles.songList}>
-      <button
-        type="button"
-        onClick={handleIndexPlay}
-        className={styles.playButton}
-      >
+      <button type="button" onClick={handleIndexPlay} className={styles.playButton}>
         <Image src={song.img} alt="" height={60} width={60} />
         <p>{song.title}</p>
       </button>
-      <button
-        type="button"
-        onClick={postFavorite}
-        className={styles.favoriteButton}
-      >
+      <button type="button" onClick={postFavorite} className={styles.favoriteButton}>
         <FavoriteIcon
           sx={{
             fontSize: 16,

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.module.css
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.module.css
@@ -1,5 +1,7 @@
 .albumSinglesContent {
+  padding-top: 5px;
   margin-top: 1rem;
+  border-top: 1px solid lightgray;
 }
 
 .albumSingleSong {

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
@@ -10,6 +10,7 @@ type PlaylistSongsAudio = {
   id: number;
   title: string;
   img: string;
+  album_id: number;
 };
 
 const PlaylistSongButtons = ({
@@ -25,7 +26,9 @@ const PlaylistSongButtons = ({
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
   audioRef: MutableRefObject<HTMLAudioElement | null>;
-  handlePlay: (type: "standard" | "continuous" | "interrupted") => Promise<void>;
+  handlePlay: (
+    type: "standard" | "continuous" | "interrupted"
+  ) => Promise<void>;
 }) => {
   return (
     <AlbumAudioProvider>

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
@@ -23,9 +23,7 @@ const PlaylistSongButtons = ({
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
   audioRef: MutableRefObject<HTMLAudioElement | null>;
-  handlePlay: (
-    type: "standard" | "continuous" | "interrupted" | "shuffle"
-  ) => Promise<void>;
+  handlePlay: (type: "standard" | "continuous" | "interrupted") => Promise<void>;
 }) => {
   return (
     <AlbumAudioProvider>

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
@@ -26,9 +26,7 @@ const PlaylistSongButtons = ({
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
   audioRef: MutableRefObject<HTMLAudioElement | null>;
-  handlePlay: (
-    type: "standard" | "continuous" | "interrupted"
-  ) => Promise<void>;
+  handlePlay: (type: "standard" | "continuous" | "interrupted") => Promise<void>;
 }) => {
   return (
     <AlbumAudioProvider>

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
@@ -14,12 +14,14 @@ type PlaylistSongsAudio = {
 
 const PlaylistSongButtons = ({
   song,
+  currentIndex,
   setCurrentIndex,
   setIsPlaying,
   audioRef,
   handlePlay,
 }: {
   song: PlaylistSongsAudio[];
+  currentIndex: number;
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
   audioRef: MutableRefObject<HTMLAudioElement | null>;
@@ -34,6 +36,7 @@ const PlaylistSongButtons = ({
               <PlaylistSongButton
                 song={song}
                 index={index}
+                currentIndex={currentIndex}
                 setCurrentIndex={setCurrentIndex}
                 setIsPlaying={setIsPlaying}
                 audioRef={audioRef}

--- a/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlbumAudioProvider } from "@/context/AlbumAudioContext";
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import PlaylistSongButton from "../PlaylistSongButton/PlaylistSongButton";
 import styles from "./PlaylistSongButtons.module.css";
 
@@ -16,12 +16,16 @@ const PlaylistSongButtons = ({
   song,
   setCurrentIndex,
   setIsPlaying,
+  audioRef,
   handlePlay,
 }: {
   song: PlaylistSongsAudio[];
   setCurrentIndex: Dispatch<SetStateAction<number>>;
   setIsPlaying: Dispatch<SetStateAction<boolean>>;
-  handlePlay: (start_flag: boolean) => Promise<void>;
+  audioRef: MutableRefObject<HTMLAudioElement | null>;
+  handlePlay: (
+    type: "standard" | "continuous" | "interrupted" | "shuffle"
+  ) => Promise<void>;
 }) => {
   return (
     <AlbumAudioProvider>
@@ -34,6 +38,7 @@ const PlaylistSongButtons = ({
                 index={index}
                 setCurrentIndex={setCurrentIndex}
                 setIsPlaying={setIsPlaying}
+                audioRef={audioRef}
                 handlePlay={handlePlay}
               />
             </div>

--- a/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.module.css
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.module.css
@@ -1,5 +1,5 @@
 .playlistList {
-  margin: 2rem 1rem;
+  margin: 1rem 1rem;
 }
 
 .noSongs {

--- a/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
@@ -12,6 +12,7 @@ type PlaylistSongsAudio = {
   id: number;
   title: string;
   img: string;
+  album_id: number
 };
 
 export const PlaylistSongList = ({

--- a/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
@@ -4,7 +4,7 @@ import SongsAudio from "@/components/music/SongsAudio/SongsAudio";
 import PlaylistSongButtons from "@/components/mypage/PlaylistDetail/PlaylistSongButtons/PlaylistSongButtons";
 import { savePlayHistory } from "@/utils/history";
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "./PlaylistSongList.module.css";
 
 type PlaylistSongsAudio = {
@@ -44,6 +44,11 @@ export const PlaylistSongList = ({
     await savePlayHistory(currentSong.id);
   };
 
+  // プレイリストから楽曲が削除されたタイミングで表示プレイリストを更新
+  useEffect(() => {
+    setPlaylistSongs(playlistSongsAudio);
+  }, [playlistSongsAudio]);
+
   return (
     <>
       {playlistSongs.length > 0 ? (
@@ -64,6 +69,7 @@ export const PlaylistSongList = ({
         {playlistSongs.length > 0 ? (
           <PlaylistSongButtons
             song={playlistSongs}
+            currentIndex={currentIndex}
             setCurrentIndex={setCurrentIndex}
             setIsPlaying={setIsPlaying}
             audioRef={audioRef}

--- a/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
@@ -12,7 +12,7 @@ type PlaylistSongsAudio = {
   id: number;
   title: string;
   img: string;
-  album_id: number
+  album_id: number;
 };
 
 export const PlaylistSongList = ({

--- a/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
+++ b/src/components/mypage/PlaylistDetail/PlaylistSongList/PlaylistSongList.tsx
@@ -23,49 +23,34 @@ export const PlaylistSongList = ({
   const [currentIndex, setCurrentIndex] = useState(0);
   // 再生中かどうかstateで管理
   const [isPlaying, setIsPlaying] = useState(false);
-  // 再生順を管理
-  const [order, setOrder] = useState<number[]>([]);
+  // 画面下部に表示するプレイリストを管理（シャッフルによる曲順変更に対応するため定義）
+  const [playlistSongs, setPlaylistSongs] = useState<PlaylistSongsAudio[]>(playlistSongsAudio);
   // 再レンダリングさせたくないので、useRefでaudio要素を参照
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const currentSong = playlistSongsAudio[order[currentIndex]];
-  const defaultOrder = () => {
-    setOrder(
-      Array.from({ length: playlistSongsAudio.length }, (_, index) => index)
-    );
-  };
-
-  // 無限増殖回避のための条件式
-  if (order.length === 0 && playlistSongsAudio.length > 0) {
-    defaultOrder();
-  }
+  const currentSong = playlistSongs[currentIndex];
 
   // 曲を再生
   // start_flagがtrueの時、プレイリストの一曲目から再生を始める。falseの時、currentIndexの曲を再生する
-  const handlePlay = async (
-    type: "standard" | "continuous" | "interrupted" | "shuffle"
-  ) => {
+  const handlePlay = async (type: "standard" | "continuous" | "interrupted") => {
     if (audioRef.current) {
+      audioRef.current.pause();
       if (type === "standard") {
-        defaultOrder();
-        setCurrentIndex(0);
-        audioRef.current.currentTime = 0;
-      } else if (type === "interrupted") {
-        defaultOrder();
-      } else if (type === "shuffle") {
         setCurrentIndex(0);
         audioRef.current.currentTime = 0;
       }
       await audioRef.current.play();
-      await savePlayHistory(currentSong.id);
       setIsPlaying(true);
     }
+    await savePlayHistory(currentSong.id);
   };
 
   return (
     <>
-      {playlistSongsAudio.length > 0 ? (
+      {playlistSongs.length > 0 ? (
         <SongsAudio
-          playlistSongsAudio={playlistSongsAudio}
+          playlistSongs={playlistSongs}
+          defaultSongs={playlistSongsAudio}
+          setPlaylistSongs={setPlaylistSongs}
           currentIndex={currentIndex}
           setCurrentIndex={setCurrentIndex}
           isPlaying={isPlaying}
@@ -73,14 +58,12 @@ export const PlaylistSongList = ({
           audioRef={audioRef}
           handlePlay={handlePlay}
           currentSong={currentSong}
-          order={order}
-          setOrder={setOrder}
         />
       ) : null}
       <div className={styles.playlistList}>
-        {playlistSongsAudio.length > 0 ? (
+        {playlistSongs.length > 0 ? (
           <PlaylistSongButtons
-            song={playlistSongsAudio}
+            song={playlistSongs}
             setCurrentIndex={setCurrentIndex}
             setIsPlaying={setIsPlaying}
             audioRef={audioRef}


### PR DESCRIPTION
## 概要 :bulb:
![image](https://github.com/user-attachments/assets/389f311b-eeab-45db-b9fe-e17ff45183ba)


- プレイリストページにシャッフル機能を追加
- シャッフル後、元の楽曲順（追加降順）に戻すボタンを作成しました。
- スキップ機能の修正
- 再生中の楽曲のスタイルを変更

## 観点 :eye:
- プレイリストページにシャッフル機能を追加
  - シャッフルボタンの押下でプレイリストの曲順を変更
  - リストボタンの押下で元の楽曲順を復元
- スキップ機能の修正
  - 前曲へのスキップボタン押下時、3秒経過以前は前の曲へ、3秒以降は再生中の楽曲の0秒へ移動するよう修正
  - 最後の曲の再生中に次曲へのスキップボタン押下時、先頭の曲へ移動し再生が停止するよう修正

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
