### PR TITLE
楽曲詳細からアルバムページへの遷移リンクの配置

### DIFF
--- a/src/app/music/[id]/page.tsx
+++ b/src/app/music/[id]/page.tsx
@@ -39,6 +39,7 @@ const SongPage = async ({ params }: SongPageProps) => {
             artist={resSongData.artist.name}
             image={resSongData.cover_xl}
             preview={resSongData.preview}
+            albumId={resSongData.album.id}
           />
         </div>
         <div className={styles.artistInfoLinkContent}>

--- a/src/components/music/SongInfoContent/SongInfoContent.tsx
+++ b/src/components/music/SongInfoContent/SongInfoContent.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { AddPlaylist } from "../AddPlaylist/AddPlaylist";
 import FavoriteButton from "../FavoriteButton/FavoriteButton";
 import SongAudio from "../SongAudio/SongAudio";
@@ -10,13 +11,16 @@ type SongInfoContentProps = {
   artist: string;
   image: string;
   preview?: string;
+  albumId: number;
 };
 
-const SongInfoContent = ({ id, title, artist, image, preview }: SongInfoContentProps) => {
+const SongInfoContent = ({ id, title, artist, image, preview, albumId }: SongInfoContentProps) => {
   return (
     <div>
       <div className={styles.songInfoContent}>
-        <Image src={image} alt={`${title}のジャケット`} width={130} height={130} priority />
+        <Link href={`/album/${albumId}`}>
+          <Image src={image} alt={`${title}のジャケット`} width={130} height={130} priority />
+        </Link>
         <div className={styles.songInfoDetail}>
           <h2>{title}</h2>
           <p>{artist}</p>


### PR DESCRIPTION
## 概要 :bulb:

- 楽曲詳細ページのアルバムのジャケ写にアルバムページへのリンクを配置

## 観点 :eye:

- アルバムページへのリンクが適切であること

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PRチェックリスト

[PRチェックリストWiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
